### PR TITLE
Enable simultaneous OpenSSL and mbed-TLS backends with runtime selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # **Changelog**
 
 ## v7.2.1 -- 07/Apr/2026
+    - TLS: change Kconfig from radio (choice) to checkboxes — both OpenSSL and mbedTLS can be
+      enabled simultaneously for runtime backend selection per connection
+    - TLS: add `__tls_libraries__` global variable (reports all compiled backends)
     - Documentation: add Test Suite page, fix glossary warnings, improve gobj-js and lib-yui READMEs
     - Remove obsolete defconfig and REVIEW.md
     - Fix duplicate measure_times declarations in yev_loop.h

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ menuconfig    # interactive TUI configurator — select compiler, build type, mo
 Key knobs:
 - Compiler: `CONFIG_USE_COMPILER_GCC=y` (default) or CLANG
 - Build type: `CONFIG_BUILD_TYPE_RELWITHDEBINFO=y` (default), Debug, Release, MinSizeRel
-- TLS: `CONFIG_HAVE_OPENSSL=y` (default) or mbed-TLS
+- TLS: `CONFIG_HAVE_OPENSSL=y` (default) and/or `CONFIG_HAVE_MBEDTLS=y` — both can be enabled for runtime selection
 - Static linking: `CONFIG_FULLY_STATIC=y` — fully static glibc binaries (GCC or Clang)
 - Debug extras: `CONFIG_DEBUG_WITH_BACKTRACE`, `CONFIG_DEBUG_TRACK_MEMORY`, `CONFIG_DEBUG_PRINT_YEV_LOOP_TIMES`
 - Optional modules: `CONFIG_MODULE_CONSOLE`, `CONFIG_MODULE_MQTT`, `CONFIG_MODULE_POSTGRES`, `CONFIG_MODULE_TEST`
@@ -248,7 +248,7 @@ Build order as processed by `yunetas` (each layer depends on all above it):
 ```
 kernel/c/gobj-c       ← core GObject framework, logging, buffers, JSON config
 kernel/c/libjwt       ← JWT authentication
-kernel/c/ytls         ← TLS abstraction (OpenSSL or mbed-TLS)
+kernel/c/ytls         ← TLS abstraction (OpenSSL and/or mbed-TLS, runtime selectable)
 kernel/c/yev_loop     ← async event loop (io_uring-based, non-blocking I/O)
 kernel/c/timeranger2  ← append-only time-series persistence
 kernel/c/root-linux   ← runtime GClasses: TCP/UDP, timers, channels, protocols, DB

--- a/Kconfig
+++ b/Kconfig
@@ -74,21 +74,26 @@ endmenu
 #------------------------------#
 #   TLS libraries
 #------------------------------#
-choice
-    prompt "TLS Library"
-    default HAVE_OPENSSL
+menu "TLS Libraries"
 
 config HAVE_OPENSSL
     bool "OpenSSL"
+    default y
     help
         Use OpenSSL as a TLS library to the YTLS API and libjwt.
+        Can be enabled together with Mbed-TLS for runtime selection.
 
 config HAVE_MBEDTLS
     bool "Mbed-TLS"
+    default n
     help
         Use mbed-tls as a TLS library to the YTLS API and libjwt.
+        Can be enabled together with OpenSSL for runtime selection.
 
-endchoice
+comment "WARNING: At least one TLS library must be selected"
+    depends on !HAVE_OPENSSL && !HAVE_MBEDTLS
+
+endmenu
 
 #------------------------------#
 #   Modules

--- a/docs/doc.yuneta.io/api/gobj/info.md
+++ b/docs/doc.yuneta.io/api/gobj/info.md
@@ -230,7 +230,8 @@ A JSON object containing the following global variables:
 | `__sys_version__`         | System version (Linux only).             |
 | `__sys_release__`         | System release (Linux only).             |
 | `__sys_machine__`         | Machine type (Linux only).               |
-| `__tls_library__`         | Active TLS backend: `"openssl"` or `"mbedtls"` (compile-time). |
+| `__tls_library__`         | Preferred TLS backend: `"openssl"` or `"mbedtls"` (compile-time, prefers OpenSSL). |
+| `__tls_libraries__`       | All enabled TLS backends: `"openssl"`, `"mbedtls"`, or `"openssl+mbedtls"` (compile-time). |
 | `__bind_ip__`             | Bind IP address of the Yuno (set when yuno is running). |
 | `__multiple__`            | Whether the Yuno allows multiple instances (boolean, set when yuno is running). |
 

--- a/docs/doc.yuneta.io/api/ytls/ytls.md
+++ b/docs/doc.yuneta.io/api/ytls/ytls.md
@@ -2,20 +2,24 @@
 
 **TLS abstraction layer** for Yuneta. Exposes a single `api_tls_t`
 dispatch table so the rest of the codebase stays backend-agnostic — the
-actual crypto can be provided by **OpenSSL** or **mbed-TLS**.
+actual crypto can be provided by **OpenSSL**, **mbed-TLS**, or **both**.
 
-## Selecting a backend
+## Selecting backends
 
-The backend is chosen at compile time via `.config` (Kconfig):
+One or both backends can be enabled at compile time via `.config` (Kconfig):
 
 ```
-CONFIG_HAVE_OPENSSL=y     # default
-CONFIG_HAVE_MBEDTLS=y     # alternative (≈3× smaller static binaries)
+CONFIG_HAVE_OPENSSL=y     # default, full-featured
+CONFIG_HAVE_MBEDTLS=y     # lightweight (≈3× smaller static binaries)
 ```
 
-The macro `TLS_LIBRARY_NAME` (defined in `ytls.h`) expands to `"openssl"`
-or `"mbedtls"`. **Always use this macro in configuration strings** instead
-of a hard-coded literal:
+When both are enabled, the preferred default is OpenSSL. Each connection
+can select its backend at runtime via the `"library"` key in the crypto
+JSON config (e.g. `"library": "mbedtls"` to override the default).
+
+The macro `TLS_LIBRARY_NAME` (defined in `ytls.h`) expands to the preferred
+backend name (`"openssl"` when available, otherwise `"mbedtls"`).
+**Always use this macro in configuration strings** instead of a hard-coded literal:
 
 ```c
 "'crypto': { 'library': '" TLS_LIBRARY_NAME "', ... }"

--- a/docs/doc.yuneta.io/guide/guide_ytls.md
+++ b/docs/doc.yuneta.io/guide/guide_ytls.md
@@ -17,9 +17,14 @@ The ytls module uses a **backend-agnostic** design. The public API (`ytls.h` / `
 - **OpenSSL** (`CONFIG_HAVE_OPENSSL`) — default, full-featured TLS backend.
 - **mbed-TLS** (`CONFIG_HAVE_MBEDTLS`) — lightweight alternative that produces ~3x smaller static binaries.
 
-The compile-time macro `TLS_LIBRARY_NAME` (defined in `ytls.h`) expands to `"openssl"` or `"mbedtls"` accordingly.
+Both backends can be enabled simultaneously. When both are present, OpenSSL is preferred as the default.
 
-At runtime, the chosen backend is available as the **yuno global variable** `__tls_library__` (set in `gobj.c`). This allows any GObj in the tree to query which TLS backend the yuno was compiled with — for example, to adapt configuration strings or log the active backend at startup.
+The compile-time macro `TLS_LIBRARY_NAME` (defined in `ytls.h`) expands to the preferred backend name: `"openssl"` when OpenSSL is enabled, otherwise `"mbedtls"`.
+
+At runtime, two **yuno global variables** are available (set in `gobj.c`):
+
+- `__tls_library__` — the preferred backend name (`"openssl"` or `"mbedtls"`), used for `(^^__tls_library__^^)` substitution in configuration strings.
+- `__tls_libraries__` — all enabled backends (`"openssl"`, `"mbedtls"`, or `"openssl+mbedtls"`), useful for diagnostics and logging.
 
 ### Source files
 

--- a/docs/doc.yuneta.io/guide/guide_ytls.md
+++ b/docs/doc.yuneta.io/guide/guide_ytls.md
@@ -12,7 +12,7 @@ The **ytls.h** header file defines the interface for the TLS (Transport Layer Se
 
 ## **Architecture**
 
-The ytls module uses a **backend-agnostic** design. The public API (`ytls.h` / `ytls.c`) exposes a single `api_tls_t` dispatch table, while the actual crypto is provided by one of two interchangeable backends selected at compile time via Kconfig:
+The ytls module uses a **backend-agnostic** design. The public API (`ytls.h` / `ytls.c`) exposes a single `api_tls_t` dispatch table, while the actual crypto is provided by two interchangeable backends configured via Kconfig (one or both can be enabled):
 
 - **OpenSSL** (`CONFIG_HAVE_OPENSSL`) — default, full-featured TLS backend.
 - **mbed-TLS** (`CONFIG_HAVE_MBEDTLS`) — lightweight alternative that produces ~3x smaller static binaries.

--- a/docs/doc.yuneta.io/guide/settings.md
+++ b/docs/doc.yuneta.io/guide/settings.md
@@ -65,7 +65,8 @@ The function replaces strings enclosed in `(^^ ^^)` with corresponding values fr
 | `__sys_version__`         | System version (Linux only).             |
 | `__sys_release__`         | System release (Linux only).             |
 | `__sys_machine__`         | Machine type (Linux only).               |
-| `__tls_library__`         | Active TLS backend: `"openssl"` or `"mbedtls"` (compile-time). |
+| `__tls_library__`         | Preferred TLS backend: `"openssl"` or `"mbedtls"` (compile-time, prefers OpenSSL). |
+| `__tls_libraries__`       | All enabled TLS backends: `"openssl"`, `"mbedtls"`, or `"openssl+mbedtls"` (compile-time). |
 | `__bind_ip__`             | Bind IP address of the Yuno.             |
 | `__multiple__`            | Whether the Yuno allows multiple instances (boolean). |
 

--- a/kernel/c/gobj-c/src/gobj.c
+++ b/kernel/c/gobj-c/src/gobj.c
@@ -6118,6 +6118,18 @@ PUBLIC json_t *gobj_global_variables(void)
     json_object_set_new(
         jn_global_variables,
         "__tls_library__",
+#if defined(CONFIG_HAVE_OPENSSL)
+        json_string("openssl")
+#elif defined(CONFIG_HAVE_MBEDTLS)
+        json_string("mbedtls")
+#else
+        json_string("")
+#endif
+    );
+
+    json_object_set_new(
+        jn_global_variables,
+        "__tls_libraries__",
 #if defined(CONFIG_HAVE_OPENSSL) && defined(CONFIG_HAVE_MBEDTLS)
         json_string("openssl+mbedtls")
 #elif defined(CONFIG_HAVE_OPENSSL)

--- a/kernel/c/gobj-c/src/gobj.c
+++ b/kernel/c/gobj-c/src/gobj.c
@@ -6118,7 +6118,9 @@ PUBLIC json_t *gobj_global_variables(void)
     json_object_set_new(
         jn_global_variables,
         "__tls_library__",
-#if defined(CONFIG_HAVE_OPENSSL)
+#if defined(CONFIG_HAVE_OPENSSL) && defined(CONFIG_HAVE_MBEDTLS)
+        json_string("openssl+mbedtls")
+#elif defined(CONFIG_HAVE_OPENSSL)
         json_string("openssl")
 #elif defined(CONFIG_HAVE_MBEDTLS)
         json_string("mbedtls")

--- a/kernel/c/root-linux/src/c_authz.c
+++ b/kernel/c/root-linux/src/c_authz.c
@@ -29,7 +29,8 @@
 #if defined(CONFIG_HAVE_OPENSSL)
     #include <openssl/ssl.h>
     #include <openssl/rand.h>
-#elif defined(CONFIG_HAVE_MBEDTLS)
+#endif
+#if defined(CONFIG_HAVE_MBEDTLS)
     #include <mbedtls/md.h>
     #include <mbedtls/private/pkcs5.h>  /* mbedtls_pkcs5_pbkdf2_hmac_ext() */
     #include <psa/crypto.h>             /* psa_generate_random(), psa_crypto_init() */
@@ -37,7 +38,8 @@
     #ifndef EVP_MAX_MD_SIZE
     #define EVP_MAX_MD_SIZE MBEDTLS_MD_MAX_SIZE
     #endif
-#else
+#endif
+#if !defined(CONFIG_HAVE_OPENSSL) && !defined(CONFIG_HAVE_MBEDTLS)
     #error "No crypto library defined"
 #endif
 #endif
@@ -390,10 +392,9 @@ PRIVATE void mt_create(hgobj gobj)
 #if defined(__linux__)
 #if defined(CONFIG_HAVE_OPENSSL)
     OpenSSL_add_all_digests();
-#elif defined(CONFIG_HAVE_MBEDTLS)
+#endif
+#if defined(CONFIG_HAVE_MBEDTLS)
     psa_crypto_init(); /* PSA must be initialised before any crypto in v4.0 */
-#else
-#error "No crypto library defined"
 #endif
 #endif
 
@@ -2708,7 +2709,7 @@ PRIVATE int gen_salt(hgobj gobj, uint8_t *salt, size_t salt_len)
         return -1;
     }
 #else
-#error "No crypto library defined"
+    #error "No crypto library defined"
 #endif
 #endif
     return 0;

--- a/kernel/c/root-linux/src/c_authz.c
+++ b/kernel/c/root-linux/src/c_authz.c
@@ -394,6 +394,7 @@ PRIVATE void mt_create(hgobj gobj)
     OpenSSL_add_all_digests();
 #endif
 #if defined(CONFIG_HAVE_MBEDTLS)
+    /* Safe to call alongside OpenSSL — PSA and OpenSSL use independent state */
     psa_crypto_init(); /* PSA must be initialised before any crypto in v4.0 */
 #endif
 #endif
@@ -2689,6 +2690,7 @@ PRIVATE int gen_salt(hgobj gobj, uint8_t *salt, size_t salt_len)
 {
 #if defined(__linux__)
 #if defined(CONFIG_HAVE_OPENSSL)
+    /* OpenSSL preferred when both backends are enabled */
     if(RAND_bytes(salt, (int)salt_len) != 1) {
         gobj_log_error(gobj, 0,
             "function",     "%s", __FUNCTION__,
@@ -2741,6 +2743,7 @@ PRIVATE int pbkdf2_any(
 
 #if defined(__linux__)
 #if defined(CONFIG_HAVE_OPENSSL)
+    /* OpenSSL preferred when both backends are enabled */
 
     EVP_MD *md = EVP_MD_fetch(NULL, digest_name, NULL);
     if(!md) {

--- a/kernel/c/ytls/src/ytls.h
+++ b/kernel/c/ytls/src/ytls.h
@@ -18,12 +18,12 @@ extern "C"{
 /***************************************************************
  *              Constants
  ***************************************************************/
-/* Compile-time name of the available TLS backend */
+/* Compile-time default TLS backend (prefers OpenSSL when both are available) */
 #include <yuneta_config.h>
-#if defined(CONFIG_HAVE_MBEDTLS)
-    #define TLS_LIBRARY_NAME "mbedtls"
-#elif defined(CONFIG_HAVE_OPENSSL)
+#if defined(CONFIG_HAVE_OPENSSL)
     #define TLS_LIBRARY_NAME "openssl"
+#elif defined(CONFIG_HAVE_MBEDTLS)
+    #define TLS_LIBRARY_NAME "mbedtls"
 #else
     #define TLS_LIBRARY_NAME ""
 #endif

--- a/modules/c/mqtt/src/c_prot_mqtt.c
+++ b/modules/c/mqtt/src/c_prot_mqtt.c
@@ -31,11 +31,13 @@
 #if defined(CONFIG_HAVE_OPENSSL)
     #include <openssl/ssl.h>
     #include <openssl/rand.h>
-#elif defined(CONFIG_HAVE_MBEDTLS)
+#endif
+#if defined(CONFIG_HAVE_MBEDTLS)
     #include <mbedtls/md.h>
     #include <mbedtls/private/pkcs5.h>  /* mbedtls_pkcs5_pbkdf2_hmac_ext() */
     #include <psa/crypto.h>             /* psa_generate_random(), psa_crypto_init() */
-#else
+#endif
+#if !defined(CONFIG_HAVE_OPENSSL) && !defined(CONFIG_HAVE_MBEDTLS)
     #error "No crypto library defined"
 #endif
 #endif

--- a/modules/c/mqtt/src/c_prot_mqtt.c
+++ b/modules/c/mqtt/src/c_prot_mqtt.c
@@ -42,9 +42,10 @@
 #endif
 #endif
 
-#if defined(CONFIG_HAVE_MBEDTLS)
+#if defined(CONFIG_HAVE_MBEDTLS) && !defined(CONFIG_HAVE_OPENSSL)
 /* Map lowercase digest name (e.g. "sha512") to mbedtls_md_info_t.
- * Returns NULL if the digest is not supported. */
+ * Returns NULL if the digest is not supported.
+ * Only needed when mbedTLS is the sole crypto backend (OpenSSL preferred). */
 static const mbedtls_md_info_t *md_info_from_name(const char *name)
 {
     char upper[32];
@@ -73,7 +74,7 @@ static const mbedtls_md_info_t *md_info_from_name(const char *name)
 
     return mbedtls_md_info_from_type(t);
 }
-#endif /* CONFIG_HAVE_MBEDTLS */
+#endif /* CONFIG_HAVE_MBEDTLS && !CONFIG_HAVE_OPENSSL */
 
 #ifdef ESP_PLATFORM
 #include "c_esp_transport.h"

--- a/modules/c/mqtt/src/c_prot_mqtt2.c
+++ b/modules/c/mqtt/src/c_prot_mqtt2.c
@@ -35,11 +35,13 @@
 #if defined(CONFIG_HAVE_OPENSSL)
     #include <openssl/ssl.h>
     #include <openssl/rand.h>
-#elif defined(CONFIG_HAVE_MBEDTLS)
+#endif
+#if defined(CONFIG_HAVE_MBEDTLS)
     #include <mbedtls/md.h>
     #include <mbedtls/private/pkcs5.h>  /* mbedtls_pkcs5_pbkdf2_hmac_ext() */
     #include <psa/crypto.h>             /* psa_generate_random(), psa_crypto_init() */
-#else
+#endif
+#if !defined(CONFIG_HAVE_OPENSSL) && !defined(CONFIG_HAVE_MBEDTLS)
     #error "No crypto library defined"
 #endif
 #endif

--- a/performance/c/perf_c_tcp/CMakeLists.txt
+++ b/performance/c/perf_c_tcp/CMakeLists.txt
@@ -75,6 +75,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/performance/c/perf_c_tcps/CMakeLists.txt
+++ b/performance/c/perf_c_tcps/CMakeLists.txt
@@ -74,6 +74,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/performance/c/perf_yev_ping_pong/CMakeLists.txt
+++ b/performance/c/perf_yev_ping_pong/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/performance/c/perf_yev_ping_pong2/CMakeLists.txt
+++ b/performance/c/perf_yev_ping_pong2/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/stress/c/listen/CMakeLists.txt
+++ b/stress/c/listen/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_mqtt/CMakeLists.txt
+++ b/tests/c/c_mqtt/CMakeLists.txt
@@ -73,6 +73,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_node_link_events/CMakeLists.txt
+++ b/tests/c/c_node_link_events/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/c_subscriptions/CMakeLists.txt
+++ b/tests/c/c_subscriptions/CMakeLists.txt
@@ -74,6 +74,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_tcp/CMakeLists.txt
+++ b/tests/c/c_tcp/CMakeLists.txt
@@ -77,6 +77,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_tcp2/CMakeLists.txt
+++ b/tests/c/c_tcp2/CMakeLists.txt
@@ -77,6 +77,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_tcps/CMakeLists.txt
+++ b/tests/c/c_tcps/CMakeLists.txt
@@ -77,6 +77,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_tcps2/CMakeLists.txt
+++ b/tests/c/c_tcps2/CMakeLists.txt
@@ -77,6 +77,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/c_timer/CMakeLists.txt
+++ b/tests/c/c_timer/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/c_timer0/CMakeLists.txt
+++ b/tests/c/c_timer0/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/kw/CMakeLists.txt
+++ b/tests/c/kw/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/msg_interchange/CMakeLists.txt
+++ b/tests/c/msg_interchange/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(${BINARY_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/timeranger2/CMakeLists.txt
+++ b/tests/c/timeranger2/CMakeLists.txt
@@ -81,6 +81,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/tr_msg/CMakeLists.txt
+++ b/tests/c/tr_msg/CMakeLists.txt
@@ -73,6 +73,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/tr_queue/CMakeLists.txt
+++ b/tests/c/tr_queue/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/tr_treedb/CMakeLists.txt
+++ b/tests/c/tr_treedb/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/tr_treedb_link_events/CMakeLists.txt
+++ b/tests/c/tr_treedb_link_events/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(${PROJECT_NAME}
     libyunetas-gobj.a
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/tests/c/yev_loop/yev_events/CMakeLists.txt
+++ b/tests/c/yev_loop/yev_events/CMakeLists.txt
@@ -89,6 +89,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tests/c/yev_loop/yev_events_tls/CMakeLists.txt
+++ b/tests/c/yev_loop/yev_events_tls/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(test ${SRCS})
         ${YUNETAS_KERNEL_LIBS}
         ${YUNETAS_EXTERNAL_LIBS}
         ${YUNETAS_PCRE_LIBS}
+        ${JWT_LIBS}
         ${OPENSSL_LIBS}
         ${MBEDTLS_LIBS}
         ${DEBUG_LIBS}

--- a/tools/cmake/project.cmake
+++ b/tools/cmake/project.cmake
@@ -160,9 +160,15 @@ set(YUNETAS_PCRE_LIBS
     libpcre2-8.a
 )
 
+# libjwt-y.a is listed separately to avoid duplication when both TLS backends are enabled
+if (CONFIG_HAVE_OPENSSL OR CONFIG_HAVE_MBEDTLS)
+    set(JWT_LIBS libjwt-y.a)
+else()
+    set(JWT_LIBS "")
+endif()
+
 if (CONFIG_HAVE_OPENSSL)
     set(OPENSSL_LIBS
-        libjwt-y.a
         libssl.a
         libcrypto.a
         pthread
@@ -174,7 +180,6 @@ endif()
 
 if (CONFIG_HAVE_MBEDTLS)
     set(MBEDTLS_LIBS
-        libjwt-y.a
         libmbedtls.a
         libmbedx509.a
         libmbedcrypto.a

--- a/utils/c/ybatch/CMakeLists.txt
+++ b/utils/c/ybatch/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/utils/c/ycommand/CMakeLists.txt
+++ b/utils/c/ycommand/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/utils/c/ystats/CMakeLists.txt
+++ b/utils/c/ystats/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/utils/c/ytests/CMakeLists.txt
+++ b/utils/c/ytests/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/utils/c/yuno-skeleton/CMakeLists.txt
+++ b/utils/c/yuno-skeleton/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/auth_bff/CMakeLists.txt
+++ b/yunos/c/auth_bff/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/controlcenter/CMakeLists.txt
+++ b/yunos/c/controlcenter/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/dba_postgres/CMakeLists.txt
+++ b/yunos/c/dba_postgres/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/emailsender/CMakeLists.txt
+++ b/yunos/c/emailsender/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/emu_device/CMakeLists.txt
+++ b/yunos/c/emu_device/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/logcenter/CMakeLists.txt
+++ b/yunos/c/logcenter/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/mqtt_broker/CMakeLists.txt
+++ b/yunos/c/mqtt_broker/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/mqtt_tui/CMakeLists.txt
+++ b/yunos/c/mqtt_tui/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/sgateway/CMakeLists.txt
+++ b/yunos/c/sgateway/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/watchfs/CMakeLists.txt
+++ b/yunos/c/watchfs/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/yuno_agent/CMakeLists.txt
+++ b/yunos/c/yuno_agent/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/yuno_agent22/CMakeLists.txt
+++ b/yunos/c/yuno_agent22/CMakeLists.txt
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}
@@ -101,6 +102,7 @@ target_link_libraries("yuneta_agent44"
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/yunos/c/yuno_cli/CMakeLists.txt
+++ b/yunos/c/yuno_cli/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}


### PR DESCRIPTION
## Summary

This change transforms the TLS backend configuration from a mutually-exclusive choice to independent toggles, allowing both OpenSSL and mbed-TLS to be compiled and selected at runtime per connection. When both are enabled, OpenSSL is preferred as the default.

## Key Changes

- **Kconfig**: Changed TLS library selection from `choice` (radio buttons) to `menu` with independent checkboxes, allowing both backends to be enabled simultaneously
- **ytls.h**: Updated `TLS_LIBRARY_NAME` macro to prefer OpenSSL when both backends are available
- **Preprocessor conditionals**: Refactored all `#if/#elif/#else` chains to independent `#if` blocks, enabling code from both backends to coexist:
  - `c_authz.c`: Separated OpenSSL and mbed-TLS includes and initialization
  - `c_prot_mqtt.c` and `c_prot_mqtt2.c`: Made mbed-TLS helper functions conditional on mbed-TLS being the sole backend
- **Global variables**: Added `__tls_libraries__` global variable to report all compiled backends (`"openssl"`, `"mbedtls"`, or `"openssl+mbedtls"`)
- **CMake**: Extracted `libjwt-y.a` into separate `JWT_LIBS` variable to prevent duplication when both backends are enabled; updated all CMakeLists.txt files to include `${JWT_LIBS}`
- **Documentation**: Updated guides and API docs to reflect dual-backend capability and runtime selection via `"library"` key in crypto JSON config
- **CHANGELOG**: Documented the configuration change and new global variable

## Implementation Details

- OpenSSL is preferred when both backends are available (checked first in `TLS_LIBRARY_NAME` macro)
- Each connection can override the default backend at runtime via the `"library"` key in crypto configuration
- PSA crypto initialization (mbed-TLS) is now safe to call alongside OpenSSL as they use independent state
- All conditional compilation blocks now allow both backends to be present simultaneously, with OpenSSL taking precedence in code paths that support only one backend

https://claude.ai/code/session_017WnUBMnnKSjdMGcjLYmQc9