### PR TITLE
Add JWT library linking to CMake build templates

### DIFF
--- a/utils/c/yuno-skeleton/skeletons/yuno_citizen/CMakeLists.txt_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/yuno_citizen/CMakeLists.txt_tmpl
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}

--- a/utils/c/yuno-skeleton/skeletons/yuno_standalone/CMakeLists.txt_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/yuno_standalone/CMakeLists.txt_tmpl
@@ -74,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
     ${YUNETAS_KERNEL_LIBS}
     ${YUNETAS_EXTERNAL_LIBS}
     ${YUNETAS_PCRE_LIBS}
+    ${JWT_LIBS}
     ${OPENSSL_LIBS}
     ${MBEDTLS_LIBS}
     ${DEBUG_LIBS}


### PR DESCRIPTION
## Summary
This change adds JWT library linking support to the CMake build configuration for both citizen and standalone Yuno skeleton templates.

## Key Changes
- Added `${JWT_LIBS}` to the `target_link_libraries()` configuration in `yuno_citizen/CMakeLists.txt_tmpl`
- Added `${JWT_LIBS}` to the `target_link_libraries()` configuration in `yuno_standalone/CMakeLists.txt_tmpl`
- The JWT library is linked after PCRE and before OpenSSL in the dependency chain

## Details
The JWT library variable is now included in the linker configuration for both skeleton templates, enabling JWT functionality in generated Yuno citizen and standalone applications. This ensures that any code using JWT operations will have the necessary library linked during the build process.

https://claude.ai/code/session_01WDLfGZb7f7EutpvDcGGF4W