### PR TITLE
Refactor ghttp_parser: remove reset(), add finish(), fix pipelining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # **Changelog**
 
 ## Unreleased
+    - **API change(ghttp_parser)**: `ghttp_parser_reset()` is **removed** from
+      the public API.  It was a foot-gun: calling it from inside an llhttp
+      callback (as `on_message_complete` used to do) corrupted llhttp's state
+      machine and silently swallowed pipelined messages.  Callers that need a
+      pristine parser for a new connection now use the destroy+create cycle
+      (see `c_prot_http_sr::ac_connected`, `c_prot_http_cl::ac_connected`,
+      `c_websocket::ac_connected`).  The llhttp settings vtable is now
+      initialised once, lazily, via `llhttp_settings_init()` in
+      `ensure_settings_initialized()`.
+    - **feat(ghttp_parser)**: new `ghttp_parser_finish()` that signals
+      end-of-stream (`llhttp_finish()`) to the parser.  Fixes a latent bug
+      where HTTP/1.0 responses (or HTTP/1.1 `Connection: close` responses
+      without `Content-Length` / `Transfer-Encoding: chunked`) never fired
+      `on_message_complete` because the peer's socket close was the only
+      message terminator.  Wired up in `c_prot_http_cl::ac_disconnected`
+      (the critical case for response parsers), `c_prot_http_sr::ac_disconnected`,
+      and `c_websocket::ac_disconnected`.
+    - **fix(ghttp_parser)**: on `HPE_PAUSED_UPGRADE`, `ghttp_parser_received()`
+      now returns the actual number of bytes llhttp consumed (computed via
+      `llhttp_get_error_pos()`) instead of lying that it consumed the whole
+      buffer.  This lets the caller re-route any tail bytes that belong to
+      the new protocol (e.g. a WebSocket frame piggy-backed on the same TCP
+      segment as the upgrade request) to the next handler.
     - **CRITICAL fix(ghttp_parser)**: HTTP/1.1 pipelining was silently broken —
       `on_message_complete()` called `ghttp_parser_reset()`, which in turn called
       `llhttp_init()` from inside the llhttp callback, corrupting the parser's

--- a/docs/doc.yuneta.io/api/appendix_api_index.md
+++ b/docs/doc.yuneta.io/api/appendix_api_index.md
@@ -2064,9 +2064,9 @@ with links to the API documentation.
 
 2. [**`ghttp_parser_received`**](helpers/http_parser.md#ghttp_parser_received) — `PUBLIC int ghttp_parser_received( GHTTP_PARSER *parser, char *bf, size_t len )`
 
-3. [**`ghttp_parser_destroy`**](helpers/http_parser.md#ghttp_parser_destroy) — `PUBLIC void ghttp_parser_destroy(GHTTP_PARSER *parser)`
+3. [**`ghttp_parser_finish`**](helpers/http_parser.md#ghttp_parser_finish) — `PUBLIC int ghttp_parser_finish(GHTTP_PARSER *parser)`
 
-4. [**`ghttp_parser_reset`**](helpers/http_parser.md#ghttp_parser_reset) — `PUBLIC void ghttp_parser_reset(GHTTP_PARSER *parser)`
+4. [**`ghttp_parser_destroy`**](helpers/http_parser.md#ghttp_parser_destroy) — `PUBLIC void ghttp_parser_destroy(GHTTP_PARSER *parser)`
 
 ### `istream.h` — 15 functions
 
@@ -2378,8 +2378,8 @@ All **957 functions** sorted alphabetically with their source header.
 | [**`get_yunetas_base`**](helpers/misc.md#get_yunetas_base) | `helpers.h` | gobj-c (Core Framework) |
 | [**`ghttp_parser_create`**](helpers/http_parser.md#ghttp_parser_create) | `ghttp_parser.h` | root-linux (Runtime GClasses) |
 | [**`ghttp_parser_destroy`**](helpers/http_parser.md#ghttp_parser_destroy) | `ghttp_parser.h` | root-linux (Runtime GClasses) |
+| [**`ghttp_parser_finish`**](helpers/http_parser.md#ghttp_parser_finish) | `ghttp_parser.h` | root-linux (Runtime GClasses) |
 | [**`ghttp_parser_received`**](helpers/http_parser.md#ghttp_parser_received) | `ghttp_parser.h` | root-linux (Runtime GClasses) |
-| [**`ghttp_parser_reset`**](helpers/http_parser.md#ghttp_parser_reset) | `ghttp_parser.h` | root-linux (Runtime GClasses) |
 | [**`glog_end`**](logging/log.md#glog_end) | `glogger.h` | gobj-c (Core Framework) |
 | [**`glog_init`**](logging/log.md#glog_init) | `glogger.h` | gobj-c (Core Framework) |
 | [**`gmtime2timezone`**](helpers/time_date.md#gmtime2timezone) | `helpers.h` | gobj-c (Core Framework) |

--- a/docs/doc.yuneta.io/api/helpers/http_parser.md
+++ b/docs/doc.yuneta.io/api/helpers/http_parser.md
@@ -100,27 +100,27 @@ Returns the number of bytes successfully parsed. Returns `-1` if an error occurs
 
 ---
 
-(ghttp_parser_reset)=
-## `ghttp_parser_reset()`
+(ghttp_parser_finish)=
+## `ghttp_parser_finish()`
 
-Resets the internal state of a `GHTTP_PARSER` structure, clearing accumulated data such as headers, body, and URL.
+Signals end-of-stream to the underlying llhttp parser (the TCP peer closed the socket). Required to complete HTTP messages whose terminator is the connection close itself — HTTP/1.0 responses without `Content-Length`, and HTTP/1.1 responses with neither `Content-Length` nor `Transfer-Encoding: chunked`. Without this call, `on_message_complete` would never fire for such messages and the subscriber would miss `EV_ON_MESSAGE`.
 
 ```C
-void ghttp_parser_reset(GHTTP_PARSER *parser);
+int ghttp_parser_finish(GHTTP_PARSER *parser);
 ```
 
 **Parameters**
 
 | Key | Type | Description |
 |---|---|---|
-| `parser` | `GHTTP_PARSER *` | Pointer to the `GHTTP_PARSER` structure to reset. |
+| `parser` | `GHTTP_PARSER *` | Pointer to the `GHTTP_PARSER` instance. |
 
 **Returns**
 
-This function does not return a value.
+`0` on success, `-1` on protocol error (e.g. a partial message was in flight when the peer closed).
 
 **Notes**
 
-This function should be called before reusing a `GHTTP_PARSER` instance to ensure a clean state.
+Call it from the gobj's disconnect handler (`ac_disconnected` / `mt_stop`). Never call it from inside an llhttp callback.
 
 ---

--- a/kernel/c/root-linux/src/c_prot_http_cl.c
+++ b/kernel/c/root-linux/src/c_prot_http_cl.c
@@ -195,7 +195,6 @@ PRIVATE int mt_stop(hgobj gobj)
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
-    ghttp_parser_reset(priv->parsing_response);
     gobj_stop(gobj_bottom_gobj(gobj));
     clear_timeout(priv->timer);
 
@@ -301,8 +300,9 @@ PRIVATE int parse_message(hgobj gobj, gbuffer_t *gbuf, GHTTP_PARSER *parser)
         int n = ghttp_parser_received(parser, bf, ln);
         if (n == -1) {
             gobj_trace_dump_full_gbuf(gobj, gbuf, "ghttp_parser_received() FAILED");
-            // Some error in parsing
-            ghttp_parser_reset(parser);
+            // Some error in parsing; caller will close the socket.
+            // No parser reset here: a fresh parser is built by
+            // ac_connected() on the next connection.
             return -1;
         } else if (n > 0) {
             gbuffer_get(gbuf, (size_t)n);  // take out the bytes consumed
@@ -340,7 +340,37 @@ PRIVATE int ac_connected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
-    ghttp_parser_reset(priv->parsing_response);
+    /*
+     *  Rebuild the response parser for the new connection.
+     *  A plain re-init of llhttp is not exposed any more; we use the
+     *  destroy+create cycle so every connection starts with a pristine
+     *  state machine.
+     */
+    if(priv->parsing_response) {
+        ghttp_parser_destroy(priv->parsing_response);
+        priv->parsing_response = 0;
+    }
+    BOOL raw_body_data = gobj_read_bool_attr(gobj, "raw_body_data");
+    if(!raw_body_data) {
+        priv->parsing_response = ghttp_parser_create(
+            gobj,
+            HTTP_RESPONSE,  // http_parser_type
+            NULL,           // on_header_event
+            NULL,           // on_body_event
+            EV_ON_MESSAGE,  // on_message_event ==> publish the full message in a gbuffer
+            FALSE           // TRUE: use gobj_send_event, FALSE: use gobj_publish_event
+        );
+    } else {
+        priv->parsing_response = ghttp_parser_create(
+            gobj,
+            HTTP_RESPONSE,  // http_parser_type
+            EV_ON_HEADER,   // on_header_event
+            EV_ON_MESSAGE,  // on_body_event  ==> publish the partial message with original buffer pointer
+            NULL,           // on_message_event
+            FALSE           // TRUE: use gobj_send_event, FALSE: use gobj_publish_event
+        );
+    }
+
     set_timeout(priv->timer, priv->timeout_inactivity);
 
     return gobj_publish_event(gobj, EV_ON_OPEN, kw); // use the same kw
@@ -353,6 +383,18 @@ PRIVATE int ac_disconnected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj sr
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
     clear_timeout(priv->timer);
+
+    /*
+     *  Signal end-of-stream to llhttp.  Critical for HTTP/1.0 responses
+     *  and Connection: close responses without Content-Length, where the
+     *  peer close is the only message terminator: llhttp will fire
+     *  on_message_complete -> EV_ON_MESSAGE right here.  Error return
+     *  is non-fatal (partial message) and the subscriber sees EV_ON_CLOSE.
+     */
+    if(priv->parsing_response) {
+        (void)ghttp_parser_finish(priv->parsing_response);
+    }
+
     return gobj_publish_event(gobj, EV_ON_CLOSE, kw); // use the same kw
 }
 

--- a/kernel/c/root-linux/src/c_prot_http_sr.c
+++ b/kernel/c/root-linux/src/c_prot_http_sr.c
@@ -315,17 +315,39 @@ PRIVATE int ac_send_message(hgobj gobj, gobj_event_t event, json_t *kw, hgobj sr
         int headers_len = strlen(headers);
         kw_decref(jn_body);
 
+        /*
+         *  RFC 7230 §3.3.2/§3.3.3: 1xx, 204 and 304 responses MUST NOT
+         *  carry a message body or Content-Length.  llhttp enforces this
+         *  strictly on the receiving side (any trailing byte after the
+         *  CRLF CRLF is parsed as the start of the next response and
+         *  fails with HPE_INVALID_CONSTANT), so emit a body-less
+         *  response regardless of what the caller passed in `body`.
+         */
+        BOOL no_body = (code[0] == '1') ||
+            (strncmp(code, "204", 3) == 0) ||
+            (strncmp(code, "304", 3) == 0);
+
         gbuf = gbuffer_create(256 + headers_len + body_len, 256 + headers_len + body_len);
-        gbuffer_printf(gbuf,
-            "HTTP/1.1 %s\r\n"
-            "%s"
-            "Content-Type: application/json; charset=utf-8\r\n"
-            "Content-Length: %d\r\n\r\n",
-            code,
-            headers,
-            body_len
-        );
-        gbuffer_append(gbuf, resp, body_len);
+        if(no_body) {
+            gbuffer_printf(gbuf,
+                "HTTP/1.1 %s\r\n"
+                "%s"
+                "\r\n",
+                code,
+                headers
+            );
+        } else {
+            gbuffer_printf(gbuf,
+                "HTTP/1.1 %s\r\n"
+                "%s"
+                "Content-Type: application/json; charset=utf-8\r\n"
+                "Content-Length: %d\r\n\r\n",
+                code,
+                headers,
+                body_len
+            );
+            gbuffer_append(gbuf, resp, body_len);
+        }
         GBMEM_FREE(resp)
     } else  {
         // Old method

--- a/kernel/c/root-linux/src/c_prot_http_sr.c
+++ b/kernel/c/root-linux/src/c_prot_http_sr.c
@@ -184,8 +184,9 @@ PRIVATE int parse_message(hgobj gobj, gbuffer_t *gbuf, GHTTP_PARSER *parser)
         char *bf = gbuffer_cur_rd_pointer(gbuf);
         int n = ghttp_parser_received(parser, bf, ln);
         if (n == -1) {
-            // Some error in parsing
-            ghttp_parser_reset(parser);
+            // Some error in parsing; caller will close the socket.
+            // No parser reset here: a fresh parser is built by
+            // ac_connected() on the next connection.
             return -1;
         } else if (n > 0) {
             gbuffer_get(gbuf, n);  // take out the bytes consumed
@@ -211,7 +212,23 @@ PRIVATE int ac_connected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
-    ghttp_parser_reset(priv->parsing_request);
+    /*
+     *  Rebuild the request parser for the new connection.
+     *  A plain re-init of llhttp is not exposed any more; we use the
+     *  destroy+create cycle so every connection starts with a pristine
+     *  state machine.
+     */
+    if(priv->parsing_request) {
+        ghttp_parser_destroy(priv->parsing_request);
+    }
+    priv->parsing_request = ghttp_parser_create(
+        gobj,
+        HTTP_REQUEST,
+        NULL,                   // on_header_event
+        NULL,                   // on_body_event
+        EV_ON_MESSAGE,
+        gobj_is_service(gobj)?FALSE:TRUE
+    );
 
     gobj_publish_event(gobj, EV_ON_OPEN, 0);
 
@@ -229,6 +246,15 @@ PRIVATE int ac_disconnected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj sr
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
     clear_timeout(priv->timer);
+
+    /*
+     *  Let llhttp complete any message whose terminator is the
+     *  connection close.  Errors here are non-fatal (they simply mean
+     *  the peer hung up mid-request).
+     */
+    if(priv->parsing_request) {
+        (void)ghttp_parser_finish(priv->parsing_request);
+    }
 
     if(gobj_is_volatil(src)) {
         gobj_set_bottom_gobj(gobj, 0);

--- a/kernel/c/root-linux/src/c_task.c
+++ b/kernel/c/root-linux/src/c_task.c
@@ -483,7 +483,7 @@ PRIVATE int stop_task(hgobj gobj, int result)
      *  Without this, every dynamic C_TASK leaks one gobj + its
      *  pure C_TIMER child on the heap until yuno teardown.
      *  Invisible in unit tests (one task per run), a slow memory
-     *  drain in production loads (one task per /auth/* request in
+     *  drain in production loads (one task per /auth/X request in
      *  c_auth_bff, etc).
      *
      *  Safe to destroy here: stop_task is invoked from

--- a/kernel/c/root-linux/src/c_websocket.c
+++ b/kernel/c/root-linux/src/c_websocket.c
@@ -1516,7 +1516,9 @@ PRIVATE int process_http(hgobj gobj, gbuffer_t *gbuf, GHTTP_PARSER *parser)
         char *bf = gbuffer_cur_rd_pointer(gbuf);
         int n = ghttp_parser_received(parser, bf, ln);
         if (n == -1) {
-            // Some error in parsing
+            // Some error in parsing; caller will close the socket.
+            // A fresh parser is built by ac_connected() on the next
+            // connection, so no in-place reset is needed here.
             const char *peername = gobj_read_str_attr(gobj, "peername");
             const char *sockname = gobj_read_str_attr(gobj, "sockname");
             gobj_log_error(gobj, 0,
@@ -1528,7 +1530,6 @@ PRIVATE int process_http(hgobj gobj, gbuffer_t *gbuf, GHTTP_PARSER *parser)
                 NULL
             );
 
-            ghttp_parser_reset(parser);
             return -1;
         } else if (n > 0) {
             gbuffer_get(gbuf, n);  // take out the bytes consumed
@@ -1565,8 +1566,30 @@ PRIVATE int ac_connected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
     priv->inform_on_close = FALSE;
     priv->close_frame_sent = FALSE;
 
-    ghttp_parser_reset(priv->parsing_request);
-    ghttp_parser_reset(priv->parsing_response);
+    /*
+     *  Rebuild both handshake parsers for the new connection.
+     *  A plain re-init of llhttp is not exposed any more; we use the
+     *  destroy+create cycle so every connection starts with a pristine
+     *  state machine.
+     */
+    if(priv->parsing_request) {
+        ghttp_parser_destroy(priv->parsing_request);
+    }
+    priv->parsing_request = ghttp_parser_create(
+        gobj,
+        HTTP_REQUEST,
+        NULL, NULL, NULL,
+        !gobj_is_service(gobj)
+    );
+    if(priv->parsing_response) {
+        ghttp_parser_destroy(priv->parsing_response);
+    }
+    priv->parsing_response = ghttp_parser_create(
+        gobj,
+        HTTP_RESPONSE,
+        NULL, NULL, NULL,
+        !gobj_is_service(gobj)
+    );
 
     if (priv->iamServer) {
         /*
@@ -1608,8 +1631,18 @@ PRIVATE int ac_disconnected(hgobj gobj, gobj_event_t event, json_t *kw, hgobj sr
         gobj_set_bottom_gobj(gobj, 0);
     }
 
-    ghttp_parser_reset(priv->parsing_request);
-    ghttp_parser_reset(priv->parsing_response);
+    /*
+     *  Signal end-of-stream to both handshake parsers.  In practice
+     *  the handshake exchange has already completed by the time we
+     *  upgrade to the websocket frame stream, so this is defensive
+     *  and errors are ignored.
+     */
+    if(priv->parsing_request) {
+        (void)ghttp_parser_finish(priv->parsing_request);
+    }
+    if(priv->parsing_response) {
+        (void)ghttp_parser_finish(priv->parsing_response);
+    }
 
     if(priv->istream_payload) {
         istream_destroy(priv->istream_payload);

--- a/kernel/c/root-linux/src/ghttp_parser.c
+++ b/kernel/c/root-linux/src/ghttp_parser.c
@@ -193,18 +193,10 @@ PUBLIC int ghttp_parser_finish(GHTTP_PARSER *parser)
     if(!parser) {
         return 0;
     }
-    hgobj gobj = parser->gobj;
 
     llhttp_errno_t err = llhttp_finish(&parser->llhttp);
     if (err != HPE_OK) {
-        gobj_log_error(gobj, 0,
-            "function",     "%s", __FUNCTION__,
-            "msgset",       "%s", MSGSET_PROTOCOL_ERROR,
-            "msg",          "%s", "llhttp_finish() FAILED",
-            "error",        "%s", llhttp_errno_name(err),
-            "desc",         "%s", llhttp_get_error_reason(&parser->llhttp),
-            NULL
-        );
+        // Silence please, check the return if necessary
         return -1;
     }
     return 0;

--- a/kernel/c/root-linux/src/ghttp_parser.c
+++ b/kernel/c/root-linux/src/ghttp_parser.c
@@ -33,16 +33,28 @@ PRIVATE int on_body(llhttp_t* llhttp, const char* at, size_t length);
 
 /****************************************************************
  *         Data
+ *
+ *  The settings table is a read-only vtable shared by every
+ *  parser instance.  It is initialised once, lazily, on the
+ *  first ghttp_parser_create() call via llhttp_settings_init().
  ****************************************************************/
-PRIVATE llhttp_settings_t settings = {
-  .on_message_begin = on_message_begin,
-  .on_url = on_url,
-  .on_header_field = on_header_field,
-  .on_header_value = on_header_value,
-  .on_headers_complete = on_headers_complete,
-  .on_body = on_body,
-  .on_message_complete = on_message_complete,
-};
+PRIVATE BOOL settings_ready = FALSE;
+PRIVATE llhttp_settings_t settings;
+
+PRIVATE void ensure_settings_initialized(void)
+{
+    if(!settings_ready) {
+        llhttp_settings_init(&settings);
+        settings.on_message_begin    = on_message_begin;
+        settings.on_url              = on_url;
+        settings.on_header_field     = on_header_field;
+        settings.on_header_value     = on_header_value;
+        settings.on_headers_complete = on_headers_complete;
+        settings.on_body             = on_body;
+        settings.on_message_complete = on_message_complete;
+        settings_ready = TRUE;
+    }
+}
 
 /***************************************************************************
  *
@@ -57,6 +69,8 @@ PUBLIC GHTTP_PARSER *ghttp_parser_create(
 )
 {
     GHTTP_PARSER *parser;
+
+    ensure_settings_initialized();
 
     /*--------------------------------*
      *      Alloc memory
@@ -91,32 +105,32 @@ PUBLIC GHTTP_PARSER *ghttp_parser_create(
  ***************************************************************************/
 PUBLIC void ghttp_parser_destroy(GHTTP_PARSER *parser)
 {
-    ghttp_parser_reset(parser);
-    GBMEM_FREE(parser);
-}
-
-/***************************************************************************
- *
- ***************************************************************************/
-PUBLIC void ghttp_parser_reset(GHTTP_PARSER *parser)
-{
-    parser->headers_completed = 0;
-    parser->message_completed = 0;
-    parser->body_size = 0;
+    if(!parser) {
+        return;
+    }
     GBMEM_FREE(parser->url);
-    //GBMEM_FREE(parser->body);
     GBUFFER_DECREF(parser->gbuf_body)
     JSON_DECREF(parser->jn_headers);
     GBMEM_FREE(parser->cur_key);
     GBMEM_FREE(parser->last_key);
-    llhttp_init(&parser->llhttp, parser->type, &settings);
-    parser->llhttp.data = parser;
-    llhttp_set_lenient_headers(&parser->llhttp, 1);
-    llhttp_set_lenient_data_after_close(&parser->llhttp, 1);
+    GBMEM_FREE(parser);
 }
 
 /***************************************************************************
- *  Return bytes consumed or -1 if error
+ *  Feed data received on the underlying TCP connection to the parser.
+ *
+ *  Return value:
+ *    > 0   Bytes consumed from `buf`.
+ *              - HPE_OK            : equals `received` (llhttp consumes the
+ *                                     whole buffer in the success case).
+ *              - HPE_PAUSED_UPGRADE: bytes consumed up to (and including)
+ *                                     the blank line of the upgrade request.
+ *                                     The tail (if any) belongs to the new
+ *                                     protocol and must be routed by the
+ *                                     caller to the next handler (e.g. the
+ *                                     first WebSocket frame piggybacked on
+ *                                     the handshake TCP segment).
+ *     -1   Protocol error.  The caller should close the connection.
  ***************************************************************************/
 PUBLIC int ghttp_parser_received(
     GHTTP_PARSER *parser,
@@ -127,8 +141,20 @@ PUBLIC int ghttp_parser_received(
 
     llhttp_errno_t err = llhttp_execute(&parser->llhttp, buf, received);
     if (err == HPE_PAUSED_UPGRADE) {
-        /* handle new protocol (upgrade) */
+        /*
+         *  Handle new protocol (upgrade).
+         *  llhttp stopped exactly after the blank line of the HTTP
+         *  upgrade request; report how many bytes of `buf` were actually
+         *  consumed so the caller can re-route the remainder to the
+         *  next protocol handler.
+         */
+        const char *stop = llhttp_get_error_pos(&parser->llhttp);
+        size_t consumed = (stop && stop >= buf) ? (size_t)(stop - buf) : received;
+        if(consumed > received) {
+            consumed = received;
+        }
         llhttp_resume_after_upgrade(&parser->llhttp);
+        return (int)consumed;
     } else if (err != HPE_OK) {
         /* Handle error. Usually just close the connection. */
         gobj_log_error(gobj,0,
@@ -146,14 +172,51 @@ PUBLIC int ghttp_parser_received(
 }
 
 /***************************************************************************
+ *  Signal end-of-stream to llhttp (the TCP peer closed the socket).
+ *
+ *  Needed to complete HTTP messages whose terminator is the connection
+ *  close — HTTP/1.0 responses without Content-Length, or HTTP/1.1
+ *  responses with neither Content-Length nor Transfer-Encoding: chunked.
+ *  Without this call llhttp would never fire on_message_complete for
+ *  those messages and the caller would hang waiting for EV_ON_MESSAGE.
+ *
+ *  Call it from the gobj's disconnect handler (ac_disconnected / mt_stop),
+ *  not from inside an llhttp callback.
+ *
+ *  Returns 0 on success, -1 on protocol error (incomplete message in
+ *  flight — the caller can ignore this when the peer was expected to
+ *  drop the socket, e.g. after a successful response was already
+ *  delivered).
+ ***************************************************************************/
+PUBLIC int ghttp_parser_finish(GHTTP_PARSER *parser)
+{
+    if(!parser) {
+        return 0;
+    }
+    hgobj gobj = parser->gobj;
+
+    llhttp_errno_t err = llhttp_finish(&parser->llhttp);
+    if (err != HPE_OK) {
+        gobj_log_error(gobj, 0,
+            "function",     "%s", __FUNCTION__,
+            "msgset",       "%s", MSGSET_PROTOCOL_ERROR,
+            "msg",          "%s", "llhttp_finish() FAILED",
+            "error",        "%s", llhttp_errno_name(err),
+            "desc",         "%s", llhttp_get_error_reason(&parser->llhttp),
+            NULL
+        );
+        return -1;
+    }
+    return 0;
+}
+
+/***************************************************************************
  *  Callbacks must return 0 on success.
  *  Returning a non-zero value indicates error to the parser,
  *  making it exit immediately.
  ***************************************************************************/
 PRIVATE int on_message_begin(llhttp_t* llhttp)
 {
-//     GHTTP_PARSER *parser = llhttp->data;
-//     ghttp_parser_reset(parser);
     return 0;
 }
 
@@ -304,17 +367,15 @@ PRIVATE int on_message_complete(llhttp_t* llhttp)
          *  Reset the per-message application state so the next pipelined
          *  request starts clean.
          *
-         *  CAREFUL: do NOT call ghttp_parser_reset() here.  That helper
-         *  calls llhttp_init(), which zeroes the llhttp internal state
-         *  (cs/sp/return-stack) — and we are still inside llhttp_execute,
-         *  about to return 0 from this callback so llhttp can keep
-         *  parsing the rest of the buffer.  Re-initing llhttp from
-         *  inside its own callback corrupts that state and llhttp
-         *  silently swallows every subsequent message in the buffer
-         *  (test8_queue_full pipelines four POSTs and only the first
-         *  one ever fired EV_ON_MESSAGE).  llhttp handles the
-         *  message-to-message transition internally for keep-alive,
-         *  so we just clear our own per-request fields.
+         *  CAREFUL: do NOT re-init llhttp here.  We are still inside
+         *  llhttp_execute, about to return 0 from this callback so llhttp
+         *  can keep parsing the rest of the buffer.  Re-initing llhttp
+         *  from inside its own callback corrupts its internal state
+         *  (cs/sp/return-stack) and llhttp silently swallows every
+         *  subsequent message in the buffer (test8_queue_full pipelines
+         *  four POSTs and only the first one ever fired EV_ON_MESSAGE).
+         *  llhttp handles the message-to-message transition internally
+         *  for keep-alive, so we just clear our own per-request fields.
          */
         parser->headers_completed = 0;
         parser->message_completed = 0;

--- a/kernel/c/root-linux/src/ghttp_parser.h
+++ b/kernel/c/root-linux/src/ghttp_parser.h
@@ -81,9 +81,19 @@ PUBLIC int ghttp_parser_received( /* Return bytes consumed or -1 if error */
     char *bf,
     size_t len
 );
-PUBLIC void ghttp_parser_destroy(GHTTP_PARSER *parser);
 
-PUBLIC void ghttp_parser_reset(GHTTP_PARSER *parser);
+/*
+ *  Signal end-of-stream to the parser (TCP peer closed the socket).
+ *  Required to complete messages whose terminator is the connection
+ *  close (HTTP/1.0 responses without Content-Length, or HTTP/1.1
+ *  responses with neither Content-Length nor Transfer-Encoding:
+ *  chunked).  Call it from the gobj's disconnect handler, never from
+ *  inside an llhttp callback.
+ *  Returns 0 on success, -1 on protocol error.
+ */
+PUBLIC int ghttp_parser_finish(GHTTP_PARSER *parser);
+
+PUBLIC void ghttp_parser_destroy(GHTTP_PARSER *parser);
 
 #ifdef __cplusplus
 }

--- a/tests/c/c_llhttp_parser/src/main.c
+++ b/tests/c/c_llhttp_parser/src/main.c
@@ -125,8 +125,8 @@ PRIVATE void test_bare_llhttp_idle(int seconds) {
     EXPECT(s_llhttp_msgs == 1, "exactly 1 on_message_complete fired");
 }
 
-PRIVATE void test_bare_llhttp_init_then_reset_then_execute(void) {
-    fprintf(stderr, "\n== bare llhttp: init + reinit + execute (mirrors ghttp_parser_reset) ==\n");
+PRIVATE void test_bare_llhttp_init_then_reinit_then_execute(void) {
+    fprintf(stderr, "\n== bare llhttp: init + reinit + execute (mirrors connection reuse) ==\n");
 
     llhttp_settings_t settings;
     llhttp_settings_init(&settings);
@@ -134,7 +134,8 @@ PRIVATE void test_bare_llhttp_init_then_reset_then_execute(void) {
 
     llhttp_t parser;
     llhttp_init_with_lenient(&parser, &settings);
-    /* Second init mirrors what ghttp_parser_reset does in c_prot_http_cl::ac_connected */
+    /* Second init mirrors the destroy+create cycle done on every new
+     * connection (ac_connected) now that ghttp_parser_reset is gone. */
     llhttp_init_with_lenient(&parser, &settings);
 
     s_llhttp_msgs = 0;
@@ -227,45 +228,77 @@ PRIVATE void test_ghttp_parser_received_after_idle(int seconds) {
     ghttp_parser_destroy(parser);
 }
 
-PRIVATE void test_ghttp_parser_create_reset_received(void) {
-    fprintf(stderr, "\n== ghttp_parser: create + reset + received (mirrors ac_connected) ==\n");
+PRIVATE void test_ghttp_parser_create_recreate_received(void) {
+    fprintf(stderr, "\n== ghttp_parser: create + destroy+create + received (mirrors ac_connected) ==\n");
 
     GHTTP_PARSER *parser = ghttp_parser_create(NULL, HTTP_RESPONSE, NULL, NULL, NULL, FALSE);
     EXPECT(parser != NULL, "ghttp_parser_create returns non-NULL");
 
     /* This is exactly what c_prot_http_cl::ac_connected does on every
-     * EV_CONNECTED — including the first one right after the gobj is
-     * started.  Make sure parsing still works after a reset on a fresh
-     * parser. */
-    ghttp_parser_reset(parser);
+     * EV_CONNECTED now that ghttp_parser_reset is gone — destroy the
+     * old parser and create a fresh one.  Make sure parsing still
+     * works right after the recreate. */
+    ghttp_parser_destroy(parser);
+    parser = ghttp_parser_create(NULL, HTTP_RESPONSE, NULL, NULL, NULL, FALSE);
+    EXPECT(parser != NULL, "re-created ghttp_parser is non-NULL");
 
     char buf[2048];
     size_t n = (size_t)snprintf(buf, sizeof(buf), "%s", RESP_204);
     int rc = ghttp_parser_received(parser, buf, n);
-    EXPECT(rc == (int)n, "received OK after reset on fresh parser");
-    EXPECT(parser && parser->message_completed == 1, "message_completed after reset");
+    EXPECT(rc == (int)n, "received OK after recreate");
+    EXPECT(parser && parser->message_completed == 1, "message_completed after recreate");
 
     ghttp_parser_destroy(parser);
 }
 
-PRIVATE void test_ghttp_parser_create_idle_reset_received(int seconds) {
-    fprintf(stderr, "\n== ghttp_parser: create + sleep %d s + reset + received ==\n", seconds);
+PRIVATE void test_ghttp_parser_create_idle_recreate_received(int seconds) {
+    fprintf(stderr, "\n== ghttp_parser: create + sleep %d s + destroy+create + received ==\n", seconds);
 
     GHTTP_PARSER *parser = ghttp_parser_create(NULL, HTTP_RESPONSE, NULL, NULL, NULL, FALSE);
     EXPECT(parser != NULL, "ghttp_parser_create returns non-NULL");
 
     sleep(seconds);
 
-    /* Reset right before the first parse, simulating the real flow:
+    /* Recreate right before the first parse, simulating the real flow:
      *   create at mt_create → wait for TCP connect (variable time) →
-     *   ac_connected resets parser → first response arrives → parse. */
-    ghttp_parser_reset(parser);
+     *   ac_connected destroys+creates parser → first response arrives → parse. */
+    ghttp_parser_destroy(parser);
+    parser = ghttp_parser_create(NULL, HTTP_RESPONSE, NULL, NULL, NULL, FALSE);
+    EXPECT(parser != NULL, "re-created ghttp_parser is non-NULL");
 
     char buf[2048];
     size_t n = (size_t)snprintf(buf, sizeof(buf), "%s", RESP_204);
     int rc = ghttp_parser_received(parser, buf, n);
-    EXPECT(rc == (int)n, "received OK after idle + reset");
-    EXPECT(parser && parser->message_completed == 1, "message_completed after idle + reset");
+    EXPECT(rc == (int)n, "received OK after idle + recreate");
+    EXPECT(parser && parser->message_completed == 1, "message_completed after idle + recreate");
+
+    ghttp_parser_destroy(parser);
+}
+
+PRIVATE void test_ghttp_parser_finish_eof(void) {
+    fprintf(stderr, "\n== ghttp_parser: EOF-terminated response fires on_message_complete via finish ==\n");
+
+    /* HTTP/1.0 response with no Content-Length — the message ends
+     * only when the peer closes the socket.  Without ghttp_parser_finish()
+     * on_message_complete never fires and EV_ON_MESSAGE is lost. */
+    const char *RESP_10_EOF =
+        "HTTP/1.0 200 OK\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "hello world";
+
+    GHTTP_PARSER *parser = ghttp_parser_create(NULL, HTTP_RESPONSE, NULL, NULL, NULL, FALSE);
+    EXPECT(parser != NULL, "ghttp_parser_create returns non-NULL");
+
+    char buf[256];
+    size_t n = (size_t)snprintf(buf, sizeof(buf), "%s", RESP_10_EOF);
+    int rc = ghttp_parser_received(parser, buf, n);
+    EXPECT(rc == (int)n, "received consumed all bytes");
+    EXPECT(parser && parser->message_completed == 0, "no message_completed yet (waiting for EOF)");
+
+    int fr = ghttp_parser_finish(parser);
+    EXPECT(fr == 0, "ghttp_parser_finish returns 0");
+    EXPECT(parser && parser->message_completed == 1, "message_completed fired by finish (EOF)");
 
     ghttp_parser_destroy(parser);
 }
@@ -327,7 +360,7 @@ int main(int argc, char *argv[])
     test_bare_llhttp_immediate();
     test_bare_llhttp_idle(1);
     test_bare_llhttp_idle(2);
-    test_bare_llhttp_init_then_reset_then_execute();
+    test_bare_llhttp_init_then_reinit_then_execute();
     test_bare_llhttp_pipelined();
 
     /* (b) ghttp_parser wrapper */
@@ -335,10 +368,11 @@ int main(int argc, char *argv[])
     test_ghttp_parser_received_immediate();
     test_ghttp_parser_received_after_idle(1);
     test_ghttp_parser_received_after_idle(2);
-    test_ghttp_parser_create_reset_received();
-    test_ghttp_parser_create_idle_reset_received(1);
-    test_ghttp_parser_create_idle_reset_received(2);
+    test_ghttp_parser_create_recreate_received();
+    test_ghttp_parser_create_idle_recreate_received(1);
+    test_ghttp_parser_create_idle_recreate_received(2);
     test_ghttp_parser_pipelined();
+    test_ghttp_parser_finish_eof();
 
     gobj_end();
 


### PR DESCRIPTION
## Summary

This PR refactors the HTTP parser API to fix a critical bug with HTTP/1.1 pipelining and improve handling of connection-close-terminated messages. The main change removes the problematic `ghttp_parser_reset()` function and introduces `ghttp_parser_finish()` to properly signal end-of-stream to llhttp.

## Key Changes

- **Removed `ghttp_parser_reset()` from public API**: This function was a foot-gun that corrupted llhttp's internal state machine when called from within callbacks (specifically `on_message_complete`), causing pipelined messages to be silently swallowed. Callers now use the destroy+create cycle for connection reuse.

- **Added `ghttp_parser_finish()` function**: New public API to signal end-of-stream (`llhttp_finish()`) to the parser. This is critical for completing HTTP/1.0 responses and HTTP/1.1 `Connection: close` responses without `Content-Length`/`Transfer-Encoding: chunked`, where the peer's socket close is the only message terminator.

- **Lazy initialization of llhttp settings**: The settings vtable is now initialized once via `llhttp_settings_init()` in a new `ensure_settings_initialized()` helper, called on first parser creation. This ensures proper initialization of all llhttp settings fields.

- **Fixed `HPE_PAUSED_UPGRADE` handling**: `ghttp_parser_received()` now returns the actual number of bytes consumed (via `llhttp_get_error_pos()`) instead of claiming the entire buffer was consumed. This allows callers to correctly re-route tail bytes belonging to the new protocol (e.g., WebSocket frames piggy-backed on the upgrade request).

- **Updated all callers**: Modified `c_prot_http_sr`, `c_prot_http_cl`, and `c_websocket` to:
  - Replace `ghttp_parser_reset()` calls with destroy+create cycles in `ac_connected()`
  - Call `ghttp_parser_finish()` in disconnect handlers (`ac_disconnected`/`mt_stop`)
  - Remove unnecessary reset calls from error paths

- **Fixed HTTP response generation**: Added RFC 7230 compliance check in `c_prot_http_sr` to ensure 1xx, 204, and 304 responses never include a message body or Content-Length header.

- **Updated tests and documentation**: Added test case for EOF-terminated responses and updated API documentation to reflect the new function signatures and usage patterns.

## Implementation Details

- The settings initialization is protected by a `settings_ready` flag to ensure single initialization
- `ghttp_parser_destroy()` now includes NULL checks and is the only way to clean up a parser
- Error handling in parse paths no longer attempts to reset the parser; connection closure is handled by the caller
- All disconnect handlers now call `ghttp_parser_finish()` to properly complete in-flight messages

https://claude.ai/code/session_01Taa5e1hMZEBUmWa2J6vnTo