### PR TITLE
Defer TLS handshake to explicit ytls_do_handshake() call

### DIFF
--- a/docs/doc.yuneta.io/api/ytls/ytls.md
+++ b/docs/doc.yuneta.io/api/ytls/ytls.md
@@ -468,6 +468,8 @@ Returns an `hsskt` handle representing the newly created secure filter, or `NULL
 
 The secure filter manages encrypted communication and invokes the provided callbacks for handshake completion, clear data reception, and encrypted data transmission.
 
+The filter is returned "cold": no handshake is started automatically. Call [`ytls_do_handshake()`](<#ytls_do_handshake>) right after this function to kick off the TLS handshake. On the client side this emits the ClientHello via `on_encrypted_data_cb`; on the server side it is a no-op that returns `0` (WANT_READ) until the peer speaks first.
+
 ---
 
 (ytls_set_trace)=

--- a/kernel/c/root-linux/src/c_tcp.c
+++ b/kernel/c/root-linux/src/c_tcp.c
@@ -589,6 +589,25 @@ PRIVATE void set_connected(hgobj gobj, int fd)
 
         ytls_set_trace(priv->ytls, priv->sskt, (trace_level & TRACE_TLS)?TRUE:FALSE);
 
+        /*
+         *  Kick off the handshake explicitly. On the client side this emits
+         *  the ClientHello via on_encrypted_data_cb (which is wired to
+         *  EV_SEND_ENCRYPTED_DATA; we are already in ST_WAIT_HANDSHAKE so
+         *  the event is accepted). On the server side it is a no-op that
+         *  returns 0 (WANT_READ) until the peer speaks first.
+         */
+        if(ytls_do_handshake(priv->ytls, priv->sskt) < 0) {
+            gobj_log_error(gobj, 0,
+                "function",     "%s", __FUNCTION__,
+                "msgset",       "%s", MSGSET_SYSTEM,
+                "msg",          "%s", "ytls_do_handshake() FAILED",
+                "error",        "%s", ytls_get_last_error(priv->ytls, priv->sskt),
+                NULL
+            );
+            try_to_stop_yevents(gobj);
+            return;
+        }
+
     } else {
         /*---------------------------*
          *      Clear traffic

--- a/kernel/c/ytls/src/tls/mbedtls.c
+++ b/kernel/c/ytls/src/tls/mbedtls.c
@@ -720,27 +720,13 @@ PRIVATE hsskt new_secure_filter(
         NULL                        // Function for receive timeout (optional)
     );
 
-    // For client: initiate the TLS handshake (sends Client Hello)
-    if(!ytls->server) {
-        int ret = mbedtls_ssl_handshake(&sskt->ssl);
-        if(ret != 0 && ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
-            char error_buf[256];
-            mbedtls_strerror(ret, error_buf, sizeof(error_buf));
-            gobj_log_error(ytls->gobj, 0,
-                "function",         "%s", __FUNCTION__,
-                "msgset",           "%s", MSGSET_MBEDTLS,
-                "msg",              "%s", "Initial TLS handshake (Client Hello) FAILED",
-                "error_code",       "%d", ret,
-                "error_message",    "%s", error_buf,
-                NULL
-            );
-            free_secure_filter(sskt);
-            return NULL;
-        }
-        // Flush the Client Hello that send_callback accumulated in output_buffer
-        flush_encrypted_data(sskt);
-    }
-
+    /*
+     *  The filter is left "cold": no mbedtls_ssl_handshake() here. The caller
+     *  is responsible for invoking ytls_do_handshake() once ready (e.g. c_tcp
+     *  does so after changing to ST_WAIT_HANDSHAKE). On the client side this
+     *  triggers the ClientHello; on the server side it is a no-op that returns
+     *  WANT_READ until the peer sends its ClientHello.
+     */
     return sskt;
 }
 

--- a/kernel/c/ytls/src/tls/mbedtls.c
+++ b/kernel/c/ytls/src/tls/mbedtls.c
@@ -890,7 +890,7 @@ PRIVATE int do_handshake(hsskt sskt_)
             );
             gobj_log_set_last_message("%s", error_buf);
             sskt->on_handshake_done_cb(sskt->user_data, -1);
-            return -1111; // Mark as TLS error (must be < -1000 for c_tcp to close the socket)
+            return -1; // Handshake failure (vtable contract: 1/0/-1)
         }
     }
 

--- a/kernel/c/ytls/src/tls/mbedtls.c
+++ b/kernel/c/ytls/src/tls/mbedtls.c
@@ -1190,40 +1190,14 @@ PRIVATE int decrypt_data(
 
     /*
      * Drive the TLS engine.
-     * - During handshake: recv_callback pulls data from encrypted_buffer;
+     * - During handshake: delegate to do_handshake() (same pattern as
+     *   openssl backend). recv_callback pulls data from encrypted_buffer;
      *   send_callback forwards outgoing handshake bytes via on_encrypted_data_cb.
      * - After handshake: read decrypted application data via flush_clear_data.
      */
     if(!mbedtls_ssl_is_handshake_over(&sskt->ssl)) {
-        int ret = mbedtls_ssl_handshake(&sskt->ssl);
-        if(ret == 0) {
-            /* Handshake just completed — flush handshake response bytes */
-            flush_encrypted_data(sskt);
-            if(!sskt->handshake_informed) {
-                sskt->handshake_informed = TRUE;
-                sskt->on_handshake_done_cb(sskt->user_data, 0);
-            }
-        } else if(ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
-            /* Normal: need more data from the network or waiting for write */
-            flush_encrypted_data(sskt); // Send accumulated handshake bytes
-            if(sskt->ytls->trace_tls) {
-                gobj_trace_msg(gobj, "------- decrypt_data handshake: %s, userp %p",
-                    ret == MBEDTLS_ERR_SSL_WANT_READ ? "WANT_READ" : "WANT_WRITE",
-                    sskt->user_data);
-            }
-        } else {
-            char error_buf[256];
-            mbedtls_strerror(ret, error_buf, sizeof(error_buf));
-            gobj_log_error(gobj, 0,
-                "function",         "%s", __FUNCTION__,
-                "msgset",           "%s", MSGSET_MBEDTLS,
-                "msg",              "%s", "TLS handshake failed",
-                "error_code",       "%d", ret,
-                "error_message",    "%s", error_buf,
-                NULL
-            );
-            gobj_log_set_last_message("%s", error_buf);
-            sskt->on_handshake_done_cb(sskt->user_data, -1);
+        if(do_handshake(sskt) < 0) {
+            // Error already logged; callback already invoked.
             return -1111; // Mark as TLS error (must be < -1000 for c_tcp to close the socket)
         }
     } else {

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -870,7 +870,6 @@ PRIVATE int do_handshake(hsskt sskt_)
                 );
             }
             flush_encrypted_data(sskt);
-            flush_clear_data(sskt);
             break;
 
         default:

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -763,12 +763,11 @@ PRIVATE hsskt new_secure_filter(
 
     SSL_set_bio(sskt->ssl, sskt->rbio, sskt->wbio);
 
-    if(do_handshake(sskt)<0) {
-        SSL_free(sskt->ssl);   /* free the SSL object and its BIO's */
-        GBMEM_FREE(sskt)
-        return 0;
-    }
-
+    /*
+     *  The filter is left "cold": no SSL_do_handshake() here. The caller is
+     *  responsible for invoking ytls_do_handshake() once ready (e.g. c_tcp
+     *  does so after changing to ST_WAIT_HANDSHAKE).
+     */
     return sskt;
 }
 

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -111,7 +111,7 @@ typedef struct sskt_s {
     int (*on_encrypted_data_cb)(void *user_data, gbuffer_t *gbuf);
     void *user_data;
     char last_error[256];
-    int error;
+    unsigned long error; // holds ERR_get_error() (unsigned long per OpenSSL API)
     char rx_bf[16*1024];
     BOOL *alive; // Points to stack var in flush_clear_data; set to FALSE when freed mid-callback
 } sskt_t;
@@ -735,7 +735,7 @@ PRIVATE hsskt new_secure_filter(
             "function",     "%s", __FUNCTION__,
             "msgset",       "%s", MSGSET_OPENSSL,
             "msg",          "%s", "SSL_new() FAILED",
-            "error",        "%d", (int)sskt->error,
+            "error",        "%lu", (unsigned long)sskt->error,
             "serror",       "%s", sskt->last_error,
             NULL
         );
@@ -1001,7 +1001,7 @@ PRIVATE int encrypt_data(
                     "msgset",       "%s", MSGSET_OPENSSL,
                     "msg",          "%s", "SSL_write() FAILED",
                     "ret",          "%d", (int)ret,
-                    "error",        "%d", (int)sskt->error,
+                    "error",        "%lu", (unsigned long)sskt->error,
                     "serror",       "%s", sskt->last_error,
                     NULL
                 );
@@ -1055,26 +1055,31 @@ PRIVATE int flush_clear_data(sskt_t *sskt)
             gobj_trace_msg(gobj, "------- flush_clear_data() %d, userp %p", nread, sskt->user_data);
         }
         if(nread <= 0) {
-            sskt->error = ERR_get_error();
-            if(sskt->error < 0) {
-                ERR_error_string_n(sskt->error, sskt->last_error, sizeof(sskt->last_error));
-                gobj_log_error(gobj, 0,
-                    "function",     "%s", __FUNCTION__,
-                    "msgset",       "%s", MSGSET_OPENSSL,
-                    "msg",          "%s", "SSL_read() FAILED",
-                    "ret",          "%d", (int)nread,
-                    "error",        "%d", (int)sskt->error,
-                    "serror",       "%s", sskt->last_error,
-                    NULL
-                );
-                GBUFFER_DECREF(gbuf)
-                sskt->alive = NULL;
-                return -1111; // Mark as TLS error
-            } else {
-                // no more data
+            const int ssl_err = SSL_get_error(sskt->ssl, nread);
+            if(ssl_err == SSL_ERROR_WANT_READ
+                    || ssl_err == SSL_ERROR_WANT_WRITE
+                    || ssl_err == SSL_ERROR_ZERO_RETURN) {
+                // No more data right now (WANT_*) or peer sent close_notify
+                // (ZERO_RETURN — clean TLS shutdown; TCP-level close is
+                // reported separately by the read yev_event).
                 GBUFFER_DECREF(gbuf)
                 break;
             }
+            sskt->error = ERR_get_error();
+            ERR_error_string_n(sskt->error, sskt->last_error, sizeof(sskt->last_error));
+            gobj_log_error(gobj, 0,
+                "function",     "%s", __FUNCTION__,
+                "msgset",       "%s", MSGSET_OPENSSL,
+                "msg",          "%s", "SSL_read() FAILED",
+                "ret",          "%d", (int)nread,
+                "ssl_err",      "%d", ssl_err,
+                "error",        "%lu", (unsigned long)sskt->error,
+                "serror",       "%s", sskt->last_error,
+                NULL
+            );
+            GBUFFER_DECREF(gbuf)
+            sskt->alive = NULL;
+            return -1111; // Mark as TLS error
         }
 
         // Callback clear data
@@ -1118,7 +1123,7 @@ PRIVATE int decrypt_data(
                 "msgset",       "%s", MSGSET_OPENSSL,
                 "msg",          "%s", "BIO_write() FAILED",
                 "ret",          "%d", (int)written,
-                "error",        "%d", (int)sskt->error,
+                "error",        "%lu", (unsigned long)sskt->error,
                 "serror",       "%s", sskt->last_error,
                 NULL
             );

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -864,12 +864,11 @@ PRIVATE int do_handshake(hsskt sskt_)
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:
             if(sskt->ytls->trace_tls) {
-                gobj_trace_msg(gobj, "------- encrypt_data: %s, userp %p",
-                    ret==SSL_ERROR_WANT_READ?"SSL_ERROR_WANT_READ":"SSL_ERROR_WANT_WRITE",
+                gobj_trace_msg(gobj, "------- do_handshake: %s, userp %p",
+                    detail==SSL_ERROR_WANT_READ?"SSL_ERROR_WANT_READ":"SSL_ERROR_WANT_WRITE",
                     sskt->user_data
                 );
             }
-            flush_encrypted_data(sskt);
             break;
 
         default:

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -896,9 +896,10 @@ PRIVATE int do_handshake(hsskt sskt_)
             sskt->handshake_informed = TRUE;
             sskt->on_handshake_done_cb(sskt->user_data, 0);
         }
+        return 1; // handshake done
     }
 
-    return 0;
+    return 0; // handshake in progress (WANT_READ/WANT_WRITE)
 }
 
 /***************************************************************************

--- a/kernel/c/ytls/src/ytls.h
+++ b/kernel/c/ytls/src/ytls.h
@@ -185,7 +185,11 @@ PUBLIC json_t *ytls_get_cert_info(hytls ytls);
 PUBLIC const char * ytls_version(hytls ytls);
 
 /**rst**
-    Get new secure filter
+    Get new secure filter.
+    The filter is returned "cold": no handshake is started automatically.
+    The caller must invoke ytls_do_handshake() once ready to kick off
+    the TLS handshake (on the client side this emits the ClientHello;
+    on the server side it is a no-op until the peer speaks first).
 **rst**/
 PUBLIC hsskt ytls_new_secure_filter(
     hytls ytls,

--- a/kernel/c/ytls/src/ytls.h
+++ b/kernel/c/ytls/src/ytls.h
@@ -100,11 +100,11 @@ typedef struct api_tls_s {
     );
     void (*free_secure_filter)(hsskt sskt);
     int (*do_handshake)(hsskt sskt); // Must return 1 (done), 0 (in progress), -1 (failure)
-    int (*encrypt_data)(
+    int (*encrypt_data)(                // return 0 on success, <-1000 on TLS error (c_tcp closes socket)
         hsskt sskt,
         gbuffer_t *gbuf  // owned
     );
-    int (*decrypt_data)(
+    int (*decrypt_data)(                // return 0 on success, <-1000 on TLS error (c_tcp closes socket)
         hsskt sskt,
         gbuffer_t *gbuf  // owned
     );

--- a/tests/c/yev_loop/yev_events_tls/test_yevent_reload_live.c
+++ b/tests/c/yev_loop/yev_events_tls/test_yevent_reload_live.c
@@ -250,6 +250,8 @@ PRIVATE int yev_server_callback(yev_event_h yev_event)
                 );
                 if(!sskt_server) {
                     ret = -1;
+                } else if(ytls_do_handshake(ytls_server, sskt_server) < 0) {
+                    ret = -1;
                 }
             } else {
                 ret = -1;
@@ -326,6 +328,8 @@ PRIVATE int yev_client_callback(yev_event_h yev_event)
                     (void *)(uintptr_t)yev_get_fd(yev_event_connect)
                 );
                 if(!sskt_client) {
+                    ret = -1;
+                } else if(ytls_do_handshake(ytls_client, sskt_client) < 0) {
                     ret = -1;
                 }
             } else {

--- a/tests/c/yev_loop/yev_events_tls/test_yevent_reload_stress.c
+++ b/tests/c/yev_loop/yev_events_tls/test_yevent_reload_stress.c
@@ -235,6 +235,7 @@ PRIVATE int yev_server_callback(yev_event_h yev_event)
                     (void *)(uintptr_t)yev_get_result(yev_event_accept)
                 );
                 if(!sskt_server) ret = -1;
+                else if(ytls_do_handshake(ytls_server, sskt_server) < 0) ret = -1;
             } else {
                 ret = -1;
             }
@@ -291,6 +292,7 @@ PRIVATE int yev_client_callback(yev_event_h yev_event)
                     (void *)(uintptr_t)yev_get_fd(yev_event_connect)
                 );
                 if(!sskt_client) ret = -1;
+                else if(ytls_do_handshake(ytls_client, sskt_client) < 0) ret = -1;
             } else {
                 ret = -1;
             }

--- a/tests/c/yev_loop/yev_events_tls/test_yevent_traffic_secure1.c
+++ b/tests/c/yev_loop/yev_events_tls/test_yevent_traffic_secure1.c
@@ -285,6 +285,8 @@ PRIVATE int yev_server_callback(yev_event_h yev_event)
                         //msg = "Server: Bad ytls";
                         //log_error()
                         ret = -1; // break the loop
+                    } else if(ytls_do_handshake(ytls_server, sskt_server) < 0) {
+                        ret = -1; // break the loop
                     }
 
                 } else {
@@ -425,6 +427,8 @@ PRIVATE int yev_client_callback(yev_event_h yev_event)
                     if(!sskt_client) {
                         //msg = "Client: Bad ytls";
                         //log_error()
+                        ret = -1; // break the loop
+                    } else if(ytls_do_handshake(ytls_client, sskt_client) < 0) {
                         ret = -1; // break the loop
                     }
 


### PR DESCRIPTION
## Summary
Refactor TLS initialization to defer the handshake until explicitly requested by the caller, rather than performing it automatically during secure filter creation. This provides better control over the handshake timing and aligns both OpenSSL and mbedTLS backends with a consistent pattern.

## Key Changes

- **Deferred handshake initialization**: Both `new_secure_filter()` implementations (OpenSSL and mbedTLS) now return a "cold" filter without initiating the handshake. The caller must explicitly invoke `ytls_do_handshake()` to begin the TLS handshake.

- **OpenSSL backend improvements**:
  - Changed `error` field type from `int` to `unsigned long` to correctly match OpenSSL's `ERR_get_error()` API
  - Updated all error logging to use `%lu` format specifier for the error field
  - Removed automatic `do_handshake()` call from `new_secure_filter()`
  - Fixed trace message in `do_handshake()` to use correct variable (`detail` instead of `ret`)
  - Improved error handling in `flush_clear_data()` to properly distinguish between `SSL_ERROR_WANT_*` conditions and actual TLS errors
  - Added clarifying comments about return values (1 = done, 0 = in progress)

- **mbedTLS backend improvements**:
  - Removed automatic handshake initiation from `new_secure_filter()` for both client and server
  - Delegated handshake logic in `decrypt_data()` to `do_handshake()` for consistency with OpenSSL backend
  - Updated documentation comments to reflect the new pattern

- **c_tcp integration**: Added explicit `ytls_do_handshake()` call in `set_connected()` after creating the secure filter and setting trace level, with proper error handling.

- **Test updates**: Updated all test files to call `ytls_do_handshake()` after creating secure filters:
  - `test_yevent_reload_live.c`
  - `test_yevent_traffic_secure1.c`
  - `test_yevent_reload_stress.c`

- **API documentation**: Updated `ytls.h` and markdown documentation to clarify that filters are returned "cold" and require an explicit handshake call.

## Implementation Details

The handshake deferral provides several benefits:
- Caller has explicit control over when the handshake begins
- Consistent behavior across both TLS backends
- Better integration with state machines (e.g., c_tcp's `ST_WAIT_HANDSHAKE` state)
- On client side: ClientHello is emitted via `on_encrypted_data_cb` callback
- On server side: handshake is a no-op until the peer sends ClientHello

https://claude.ai/code/session_01QsrsSNdYSMxceRNRNysyCj