### PR TITLE
Clear OpenSSL error queue before SSL operations to prevent stale errors

### DIFF
--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -844,6 +844,13 @@ PRIVATE int do_handshake(hsskt sskt_)
         gobj_trace_msg(gobj, "------- do_handshake, userp %p", sskt->user_data);
     }
 
+    /*
+     * SSL_get_error() consults the thread-local error queue to classify the
+     * result of the SSL operation. Any stale error left by unrelated code
+     * (e.g. libjwt RSA signature verification) will make SSL_get_error()
+     * misreport a benign WANT_READ/WANT_WRITE as SSL_ERROR_SSL.
+     */
+    ERR_clear_error();
     int ret = SSL_do_handshake(sskt->ssl);
     if(ret <= 0)  {
         /*
@@ -976,6 +983,7 @@ PRIVATE int encrypt_data(
     size_t len;
     while(sskt->ssl && (len = gbuffer_chunk(gbuf))>0) {
         const char *p = gbuffer_cur_rd_pointer(gbuf);    // Don't pop data, be sure it's written
+        ERR_clear_error(); // see do_handshake() note on stale error-queue entries
         const int written = SSL_write(sskt->ssl, p, len);
         if(written <= 0) {
             const int ret = SSL_get_error(sskt->ssl, written);
@@ -1049,6 +1057,7 @@ PRIVATE int flush_clear_data(sskt_t *sskt)
     while(sskt->ssl) {
         gbuffer_t *gbuf = gbuffer_create(sskt->ytls->rx_buffer_size, sskt->ytls->rx_buffer_size);
         char *p = gbuffer_cur_wr_pointer(gbuf);
+        ERR_clear_error(); // see do_handshake() note on stale error-queue entries
         int nread = SSL_read(sskt->ssl, p, sskt->ytls->rx_buffer_size);
         if(sskt->ytls->trace_tls) {
             gobj_trace_msg(gobj, "------- flush_clear_data() %d, userp %p", nread, sskt->user_data);


### PR DESCRIPTION
## Summary
This change fixes a bug where stale errors left in OpenSSL's thread-local error queue by unrelated code could cause SSL operations to be misreported as failures. By clearing the error queue before critical SSL operations, we ensure that `SSL_get_error()` accurately reflects the actual result of the operation.

## Key Changes
- **do_handshake()**: Added `ERR_clear_error()` before `SSL_do_handshake()` to prevent stale errors from being misclassified as SSL errors
- **encrypt_data()**: Added `ERR_clear_error()` before `SSL_write()` with explanatory comment referencing the do_handshake() rationale
- **flush_clear_data()**: Added `ERR_clear_error()` before `SSL_read()` with the same explanatory comment

## Implementation Details
The issue occurs because `SSL_get_error()` consults the thread-local error queue to classify SSL operation results. If unrelated code (such as libjwt RSA signature verification) leaves errors in this queue, benign conditions like `WANT_READ` or `WANT_WRITE` can be misreported as `SSL_ERROR_SSL`.

The fix is minimal and surgical—clearing the error queue immediately before each SSL operation ensures a clean state for error classification. Comments have been added to explain the rationale and prevent future confusion about why these calls are necessary.

https://claude.ai/code/session_0132vTWWuPjnJaK2drtiXi4b