### PR TITLE
docs(lib-yui): rework TODO.md after review iteration

### DIFF
--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -1,20 +1,3 @@
-Listo. 11 tareas en el TODO, ordenadas por dependencia (lo primero cierra el círculo de live-translate visualmente; lo último abre el PR). Cada una con criterio de "hecho" claro:
-
-1. **Botón ES/EN en la test-app toolbar** — smoke visual de `yui_shell_set_translate`.
-2. **Bump 7.4.0 + CHANGELOG** — empaquetar la entrega.
-3. **Modales/notificaciones sobre los layers del shell** — porting de `display_*` y `get_yes*` desde `C_YUI_MAIN`, generalizando el focus-trap de drawer a cualquier overlay.
-4. **`C_YUI_TABS` a `EV_ROUTE_CHANGED`** — primer consumidor migrado del routing antiguo.
-5. **Inventario + migración del resto de consumidores** — `treedb_*`, `g6_nodes_tree`.
-6. **`estadodelaire/gui` al shell** — primer test real con datos.
-7. **Borrar `C_YUI_MAIN` y `C_YUI_ROUTING`** — cuando los `grep` estén vacíos; bump 7.5.0 (breaking).
-8. **Generalizar el loop de secundarios** más allá de `menu.primary`.
-9. **Cadena de prioridad de `Escape`** — pila modal > drawer > popup.
-10. **e2e con Playwright** — booteo + dos presets + lifecycle + live-translate + focus-trap.
-11. **PR + `/ultrareview`** — antes de mergear.
-
-Si confirmas que el orden te encaja, puedo empezar por la #1 (botón ES/EN en la toolbar) — es el más visible y cierra el último work item del review original. Avísame.
-
-
 # `lib-yui` shell — pending work
 
 Living TODO for the declarative shell refactor on branch
@@ -28,6 +11,23 @@ The arc this list closes:
 > ("Status and retirement plan") plus the polish items spilled out of
 > the iteration.  When this list is empty, `C_YUI_MAIN` and
 > `C_YUI_ROUTING` can be deleted from `lib-yui`.
+
+Order rationale (revised after review):
+
+- #1 + #2 close the original review scope and let us cut a `7.4.0`
+  release on top of which the migration can ride.
+- #3 (Escape stack) lands **before** #4 (modals) on purpose: any
+  modal/popup component will register itself on the stack, retro-
+  fitting it after the fact is much more painful.
+- #4 → #5 → #6 are the migration spine: shell-side helpers, then
+  one consumer (`C_YUI_TABS`) end-to-end, then the rest of the
+  inventory.
+- #7 (real-world test on `estadodelaire/gui`) gates #8 (deletion of
+  legacy classes).
+- #9 / #10 are independent improvements that can land at any time
+  but are most useful **before** #6 / #7 (smoke coverage during the
+  risky migration).
+- #11 closes the branch.
 
 ---
 
@@ -49,9 +49,16 @@ exercises it.  Add a tiny visible loop:
   `nav_label`) and every toolbar `<button>` label should swap.
 - Update `test-app/README.md` with a "Live i18n" section.
 
+**Caveat to document:** `yui_shell_set_translate` only re-publishes
+`EV_ROUTE_CHANGED` when `current_route` is non-empty.  If the user
+clicks the language toggle *before* the first navigation has
+succeeded, navs are rebuilt but the active highlight is empty until
+they navigate.  Surface this in the README so it doesn't surprise
+integrators.
+
 **Done when:** clicking the ES/EN button visibly relabels every menu,
-heading and toolbar button, and the active item highlight survives the
-re-publish of `EV_ROUTE_CHANGED`.
+heading and toolbar button, and the active item highlight survives
+the re-publish of `EV_ROUTE_CHANGED`.
 
 ---
 
@@ -73,43 +80,75 @@ publish:
       drawer staying open after navigation, vite alias matching
       sub-paths, missing drawer helper re-exports, ugly
       `secondary.<id>` heading via the new `nav_label` attribute.
-    - **Note**: `C_YUI_MAIN` and `C_YUI_ROUTING` are still shipped and
-      not deprecated yet.  Migration is tracked in
-      `kernel/js/lib-yui/TODO.md` and `kernel/js/lib-yui/SHELL.md` §10.
+    - **Note**: `C_YUI_MAIN` and `C_YUI_ROUTING` are still shipped
+      and not deprecated yet.  Migration is tracked in
+      `kernel/js/lib-yui/TODO.md` and `kernel/js/lib-yui/SHELL.md`
+      §10.
 
 **Done when:** version bumped, CHANGELOG entry merged.
 
 ---
 
-## 3. Modal / notification API on top of the shell layers
+## 3. Escape priority chain (modal > drawer > popup)
+
+The shell's global `keydown` listener unconditionally closes any
+open drawer on `Escape`.  Once modals (#4) and any future popup
+component land, this becomes wrong — closing the modal first,
+*then* the drawer, *then* the popup is the universal expectation.
+
+**Land this BEFORE #4** so modals are born already aware of the
+stack.
+
+- Refactor `priv.keydown_handler` into a stack `priv.escape_stack`:
+  an array of close handlers.  Each interactive overlay pushes its
+  handler when it opens and pops it when it closes.  Escape calls
+  the **top** handler only and consumes the event.
+- Order of priority by `z-index` of the layer the overlay lives in:
+  `loading` (no Escape) > `modal` > `popup` > `overlay` (drawer).
+- Refactor `open_drawer` / `close_drawer` / `toggle_drawer` to use
+  the stack instead of calling `close_all_drawers` directly.
+- Document the order in `SHELL.md` §11 and add a regression test in
+  the e2e suite once #10 is up.
+
+**Done when:** with a modal open over a drawer, Escape closes the
+modal first; second Escape closes the drawer.
+
+---
+
+## 4. Modal / notification API on top of the shell layers
 
 Today the shell creates `priv.layers.modal`, `priv.layers.notification`
 and `priv.layers.loading` in `build_ui` but exposes no API for them.
 The legacy entry points still live in `c_yui_main.js`:
-`display_volatil_modal`, `display_info_message`, `display_warning_message`,
-`display_error_message`, `get_yesnocancel`, `get_yesno`, `get_ok`.
+`display_volatil_modal`, `display_info_message`,
+`display_warning_message`, `display_error_message`,
+`get_yesnocancel`, `get_yesno`, `get_ok`.
 
-- Port each helper to a shell-level function that paints into the
-  corresponding layer.  Keep the same exported names (drop-in
-  replacement) and re-export them from `index.js`.
-- Reuse Bulma's `.modal` / `.notification` markup verbatim for visual
-  parity.
 - **Generalise** the drawer focus-trap (`activate_focus_trap` /
   `release_focus_trap` / `FOCUSABLE_SELECTOR`) into a generic
-  `activate_focus_trap_on($element)` that any modal / drawer / popup
-  can use.  Move it into `src/shell_focus_trap.js` for unit-testability
-  alongside `shell_show_on.js`.
-- Add a smoke entry in `test-app/app_config.json`: a toolbar item that
-  fires `display_info_message("Hello")` so the toast renders without
-  any view doing it.
+  `activate_focus_trap_on($element)` and move it to
+  `src/shell_focus_trap.js` for unit-testability alongside
+  `shell_show_on.js`.  Add a small `tests/shell_focus_trap.test.mjs`
+  using happy-dom (or a tiny stub) so the runner gets its second
+  client.
+- Port each `display_*` / `get_yes*` helper to a shell-level function
+  that paints into the corresponding layer.  Keep the same exported
+  names (drop-in replacement) and re-export them from `index.js`.
+- Reuse Bulma's `.modal` / `.notification` markup verbatim for visual
+  parity with the legacy implementation.
+- Each modal/popup that grabs focus must register a close handler on
+  the Escape stack from #3.
+- Add a smoke entry in `test-app/app_config.json`: a toolbar item
+  that fires `display_info_message("Hello")` so the toast renders
+  without any view doing it.
 
-**Done when:** every existing call to `display_*` from `c_yui_main.js`
-can be served from the shell, and `c_yui_main.js` is no longer the
-authority for modals/toasts.
+**Done when:** every existing call to `display_*` / `get_yes*` from
+`c_yui_main.js` can be served from the shell, and `c_yui_main.js` is
+no longer the authority for modals/toasts.
 
 ---
 
-## 4. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
+## 5. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
 
 `C_YUI_TABS.ac_show` / `ac_hide` listen to `EV_ROUTING_CHANGED` of
 `C_YUI_ROUTING`.  Move that subscription to the shell's
@@ -120,21 +159,22 @@ authority for modals/toasts.
   "EV_ROUTE_CHANGED", {}, gobj)`.  In `mt_stop`: unsubscribe.
 - Keep the legacy `C_YUI_ROUTING` path as a fallback when `shell` is
   not set, so the migration can land before consumers are converted.
-  Mark the fallback `// transitional` and link to this TODO.
+  Mark the fallback `// transitional — remove after TODO #6` and link
+  to this TODO.
 - Add a small test-app stage that uses tabs to confirm.
 
-**Done when:** the test-app + `estadodelaire/gui` (after task #6) work
+**Done when:** the test-app + `estadodelaire/gui` (after #7) work
 without registering `C_YUI_ROUTING`.
 
 ---
 
-## 5. Inventory and migrate the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
+## 6. Inventory and migrate the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
 
 ```
 grep -r register_c_yui_main      kernel/ utils/ yunos/
 grep -r register_c_yui_routing   kernel/ utils/ yunos/
 grep -rl EV_ROUTING_CHANGED      kernel/ utils/ yunos/
-grep -rl display_(error|info|warning|volatil) kernel/ utils/ yunos/
+grep -rlE 'display_(error|info|warning|volatil)|get_yes|get_ok' kernel/ utils/ yunos/
 ```
 
 For every hit that is not the migration itself, open a sub-task here.
@@ -150,22 +190,24 @@ Likely consumers inside `lib-yui`:
 Each consumer:
 
 - Replace `EV_ROUTING_CHANGED` subscription with `EV_ROUTE_CHANGED`
-  (via the shell, see task #4).
-- Replace `display_*` calls with the shell-helper version (task #3).
+  (via the shell, see #5).
+- Replace `display_*` / `get_yes*` calls with the shell-helper
+  version (#4).
 - Drop the dependency on the old gclasses from its imports.
 
-**Done when:** the two `grep`s above return empty inside `lib-yui`
+**Done when:** the four `grep`s above return empty inside `lib-yui`
 itself.
 
+---
 
-## 6. Migrate `estadodelaire/gui` to the shell — first real-world test
+## 7. Migrate `estadodelaire/gui` to the shell — first real-world test
 
-The companion repo `artgins/estadodelaire` is the canonical app on top
-of `lib-yui`.  Replace its bootstrap:
+The companion repo `artgins/estadodelaire` is the canonical app on
+top of `lib-yui`.  Replace its bootstrap:
 
 - `gui/src/main.js`: drop `register_c_yui_main / register_c_yui_routing`,
-  add `register_c_yui_shell / register_c_yui_nav` and
-  `register_c_test_view`-style registrations for every `c_ui_*` gclass.
+  add `register_c_yui_shell / register_c_yui_nav` and registrations
+  for every `c_ui_*` gclass.
 - `gui/src/c_yuneta_gui.js`: replace its custom shell wiring with a
   declarative `app_config.json` next to it.  Each `c_ui_*` gclass
   becomes a `target.gclass` with the appropriate `lifecycle`:
@@ -175,37 +217,45 @@ of `lib-yui`.  Replace its bootstrap:
     - `c_ui_historical_chart` → `lazy_destroy` (heavy, infrequent).
     - `c_ui_monitoring` / `c_ui_monitoring_group` → `keep_alive`.
     - `c_ui_todo` / `c_yui_gobj_tree_js` → `lazy_destroy`.
+- **Verify CSS class scope.**  `c_yui_shell.css` defines generic
+  selectors (`.yui-toolbar`, `.yui-stage > *`, `.yui-zone-center > *`,
+  `.yui-nav-iconbar .yui-nav-item.is-active`, etc.).  Confirm none
+  of them collide with classes used by the `c_ui_*` views.  If they
+  do, add the `.yui-shell` ancestor selector to scope shell rules.
 - Verify on real screen sizes:
-    - Mobile (<769): primary as `icon-bar` at `bottom`, submenu as `tabs`
-      at `top-sub`, drawer for the user/account menu.
+    - Mobile (<769): primary as `icon-bar` at `bottom`, submenu as
+      `tabs` at `top-sub`, drawer for the user/account menu.
     - Tablet (769-1023): same primary placement + toolbar appears at
       `top`.
-    - Desktop (≥1024): primary at `left` (vertical), submenu at `right`
-      (vertical), full toolbar.
+    - Desktop (≥1024): primary at `left` (vertical), submenu at
+      `right` (vertical), full toolbar.
 - Confirm the live language switch using existing locales/flags
   (`gui/src/locales/`).
-- Capture any feature gap (a layout the current GUI does that the new
-  shell doesn't) as a follow-up here before continuing.
+- **If a feature gap appears** (a layout the current GUI does that
+  the new shell doesn't), capture it as a follow-up here **before
+  continuing**.  Do not patch around it ad-hoc inside `gui/`.
 
 **Done when:** `cd gui && npm run dev` boots EstadoDelAire on the new
 shell and the smoke flows (alarms, monitoring, history) work.
 
 ---
 
-## 7. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
+## 8. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
 
-Gated on tasks #3, #4, #5 and #6.  The retirement checklist
+Gated on tasks #4, #5, #6 and #7.  The retirement checklist
 documented in `SHELL.md` §10 must be empty:
 
 ```
-grep -r register_c_yui_main   kernel/ utils/ yunos/   # empty
-grep -r register_c_yui_routing kernel/ utils/ yunos/   # empty
+grep -r register_c_yui_main      kernel/ utils/ yunos/   # empty
+grep -r register_c_yui_routing   kernel/ utils/ yunos/   # empty
+grep -rl EV_ROUTING_CHANGED      kernel/ utils/ yunos/   # empty
+grep -rlE 'display_(error|info|warning|volatil)|get_yes|get_ok' kernel/ utils/ yunos/  # empty
 ```
 
 Then:
 
-- Delete `src/c_yui_main.js`, `src/c_yui_main.css`, `src/c_yui_routing.js`,
-  `src/c_yui_routing.css`.
+- Delete `src/c_yui_main.js`, `src/c_yui_main.css`,
+  `src/c_yui_routing.js`, `src/c_yui_routing.css`.
 - Remove their exports from `index.js`.
 - Drop `import "@yuneta/lib-yui/src/c_yui_main.css"` /
   `c_yui_routing.css` from any remaining `main.js` (test-app should
@@ -218,10 +268,12 @@ Then:
 - Bump `lib-yui` to `7.5.0` (breaking change).  Add CHANGELOG entry
   with the removal and link to this TODO.
 
-**Done when:** `lib-yui` no longer ships either gclass and no consumer
-inside the org references them.
+**Done when:** `lib-yui` no longer ships either gclass and no
+consumer inside the org references them.
 
-## 8. Generalise the secondary-nav loop beyond `menu.primary`
+---
+
+## 9. Generalise the secondary-nav loop beyond `menu.primary`
 
 `instantiate_menus()` in `c_yui_shell.js` walks only
 `menus.primary.items[*].submenu` to build level-2 navs.  See
@@ -229,71 +281,67 @@ inside the org references them.
 
 - Walk every menu mounted via a zone host of the form `"menu.<id>"`
   whose items declare a `submenu`, not just `primary`.  The
-  `secondary.<item.id>` synthesised id stays unique because item ids
-  are scoped to their parent menu — but if collisions across menus
-  become a concern, switch to `secondary.<menu_id>.<item.id>`.
+  `secondary.<item.id>` synthesised id stays unique because item
+  ids are scoped to their parent menu — but if collisions across
+  menus become a concern, switch to
+  `secondary.<menu_id>.<item.id>`.
 - Update `SHELL.md` §11 to drop limitation #1 (and renumber).
-- Add a regression case to the test-app: a second primary-style menu
-  (e.g. `menu.admin`) with its own submenus, and verify the right
-  secondary nav surfaces under the right primary.
+- Add a regression case to the test-app: a second primary-style
+  menu (e.g. `menu.admin`) with its own submenus, and verify the
+  right secondary nav surfaces under the right primary.
 
-**Done when:** the test-app has at least two primary-style menus with
-submenus and both render their secondary navs correctly.
+**Done when:** the test-app has at least two primary-style menus
+with submenus and both render their secondary navs correctly.
 
-## 9. Escape priority chain (modal > drawer > popup)
-
-The shell's global `keydown` listener unconditionally closes any open
-drawer on `Escape`.  Once modals (task #3) and any future popup
-component land, this becomes wrong.
-
-- Refactor into a stack `priv.escape_stack`: an array of close
-  handlers.  Each interactive overlay pushes its handler when it
-  opens and pops it when it closes.  Escape calls the top handler
-  only.
-- Order of priority by `z-index` of the layer the overlay lives in:
-  `loading` (no Escape) > `modal` > `popup` > `overlay` (drawer).
-- Document the order in `SHELL.md`.
-
-**Done when:** with a modal open over a drawer, Escape closes the
-modal first; second Escape closes the drawer.
+---
 
 ## 10. End-to-end smoke with Playwright
 
 Today there is **no automated smoke** of the shell — only the 13
-`shell_show_on` parser tests run in CI.  Add a thin Playwright suite:
+`shell_show_on` parser tests run in CI.  Add a thin Playwright
+suite.
+
+**Land at least the "boot + navigate primary" subset BEFORE #6**
+so the migration of consumers in #6 is caught instantly when it
+breaks something.  The full catalogue can grow incrementally.
 
 - Boot the test-app via `vite preview` against the built bundle.
 - Two presets, two browsers (chromium + firefox at minimum).
-- Tests:
-    - **boot**: `/dash/ov` renders, the card title is "Overview".
-    - **navigation**: clicking each primary item changes the active
-      highlight and the centre stage.
-    - **breakpoint**: viewport at 800px shows the bottom icon-bar; at
-      1280px shows the left vertical menu.
-    - **drawer**: hamburger opens drawer, focus moves into the panel,
-      `Tab` cycles inside, `Escape` closes and restores focus to the
-      burger button.
-    - **lifecycle**: visiting `/dash/alerts` (`lazy_destroy`) twice
-      increments the `instance #` counter; `/dash/ov` (`keep_alive`)
-      does not.
-    - **live-translate**: clicking the ES/EN button (task #1) flips
-      labels everywhere.
+- Tests, in order of priority (the first two are the gate for #6):
+    1. **boot**: `/dash/ov` renders, the card title is "Overview".
+    2. **navigation**: clicking each primary item changes the
+       active highlight and the centre stage.
+    3. **breakpoint**: viewport at 800 px shows the bottom
+       icon-bar; at 1280 px shows the left vertical menu.
+    4. **drawer**: hamburger opens drawer, focus moves into the
+       panel, `Tab` cycles inside, `Escape` closes and restores
+       focus to the burger button.
+    5. **escape stack** (after #3): modal over drawer, Escape
+       closes the modal first, then the drawer.
+    6. **lifecycle**: visiting `/dash/alerts` (`lazy_destroy`)
+       twice increments the `instance #` counter; `/dash/ov`
+       (`keep_alive`) does not.
+    7. **live-translate**: clicking the ES/EN button (#1) flips
+       labels everywhere.
 - Wire `npm run test:e2e` from `kernel/js/lib-yui/`.
-- Add a CI workflow stub (`.github/workflows/lib-yui.yml`) that runs
-  `npm test` (parser) + `npm run test:e2e` on PRs touching
+- Add a CI workflow stub (`.github/workflows/lib-yui.yml`) that
+  runs `npm test` (parser) + `npm run test:e2e` on PRs touching
   `kernel/js/lib-yui/**`.
 
-**Done when:** CI green on the branch and the workflow gates the PR.
+**Done when:** CI green on the branch and the workflow gates the
+PR.
+
+---
 
 ## 11. Open PR + run `/ultrareview` before merging to `main`
 
-Convention: feature branches are independently reviewed before they
-land.
+Convention: feature branches are independently reviewed before
+they land.
 
 - Open the PR `claude/refactor-gui-system-qptVn → main` once tasks
-  #1–#10 are at a place where merging is desirable (does not require
-  every task to be done — at minimum #1 + #2 close the original
-  review scope).
+  #1–#10 are at a place where merging is desirable (does not
+  require every task to be done — at minimum #1 + #2 close the
+  original review scope).
 - The user runs `/ultrareview <PR#>` for a multi-agent independent
   review.
 - Triage findings into either: (a) immediate fixes on the same PR;


### PR DESCRIPTION
Restructured the migration TODO based on feedback:

- Promoted "Escape priority chain" to #3 (was #9). Modals (#4) will register on the stack; doing #4 first and #3 later forces a retrofit, so flipping the order saves real work.
- Renumbered the rest of the chain accordingly: modals=#4, C_YUI_TABS=#5, inventory=#6, estadodelaire=#7, delete=#8, generalise secondary=#9. e2e=#10 and PR=#11 are unchanged.
- Updated cross-references (#7's gating list, "after task #6" → "after task #7", etc.) so the new numbers are consistent.
- Replaced the chat-style Spanish preamble with a short English rationale for the ordering — keeps the doc in English per the repo convention without losing intent.
- Added explicit "land BEFORE #4" / "land BEFORE #6" markers on #3 and #10 so the dependency story is visible at a glance, and reordered #10's test list so the gate-for-#6 subset (boot + navigate) is at the top.
- Generalised the focus-trap as part of #4 (move to src/shell_focus_trap.js, add tests/shell_focus_trap.test.mjs) so it's not stuck inside the drawer code.
- Extended the migration grep regex to cover get_yes / get_ok in both #6 and #8 (the original regex only caught display_*).
- Added a CSS-class-scope check inside #7 (estadodelaire migration): c_yui_shell.css uses generic selectors like .yui-toolbar / .yui-stage > * that may collide with c_ui_* views; verify in the first real-world consumer.
- Added a caveat in #1: yui_shell_set_translate is a no-op for the active-item highlight if called before the first navigate_to has succeeded; document it in the test-app README.
- Reinforced the "if a feature gap appears, capture it as a follow-up here BEFORE continuing" rule for #7 — do not patch estadodelaire ad-hoc when the shell is the missing piece.