### PR TITLE
lib-yui: coexistence model + TODO #1 (live-i18n smoke)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,7 @@
 {
-    "esversion": 6,
+    "esversion": 11,
     "laxbreak": true,
+    "forin": false,
+    "loopfunc": true,
     "sub": true
 }

--- a/kernel/js/lib-yui/README.md
+++ b/kernel/js/lib-yui/README.md
@@ -4,13 +4,33 @@ Reusable GUI components for building Yuneta-based web applications. Every
 component is a GClass (from [`@yuneta/gobj-js`](https://www.npmjs.com/package/@yuneta/gobj-js))
 that plugs into the GObject tree and communicates via events.
 
-The library provides:
+## Which app shell to use?
 
-- **App shell** (`C_YUI_MAIN`) — layered layout with toolbar, modals, and notifications.
+`lib-yui` ships two app-shell stacks. They coexist; pick one per app.
+
+- **New GUIs → `C_YUI_SHELL` + `C_YUI_NAV`** (declarative shell, since
+  v7.4.0). JSON-driven layout, routed stages, drawer overlay with
+  focus-trap, hot-swap i18n. See [`SHELL.md`](./SHELL.md).
+- **Existing GUIs → keep `C_YUI_MAIN` + `C_YUI_ROUTING`.** Both are
+  still shipped and supported. Migrating is opt-in, not mandated;
+  there is no scheduled removal.
+
+The two stacks **do not share CSS** — do not import
+`c_yui_main.css` and `c_yui_shell.css` together. One app picks one
+stack.
+
+## Components
+
+- **App shell (declarative)** (`C_YUI_SHELL` + `C_YUI_NAV`) — JSON-driven
+  zones, menus, toolbar, drawers, lifecycle. Recommended for new GUIs.
+- **App shell (legacy)** (`C_YUI_MAIN`) — layered layout with toolbar,
+  modals, and notifications. Still supported for existing GUIs.
 - **Window manager** (`C_YUI_WINDOW`) — draggable/resizable floating windows.
 - **Tabs** (`C_YUI_TABS`) — tab container for sub-components.
 - **Form builder** (`C_YUI_FORM`) — dynamic forms backed by Tabulator and TomSelect.
-- **Routing** (`C_YUI_ROUTING`) — hash-based menu/content routing.
+- **Routing (legacy)** (`C_YUI_ROUTING`) — hash-based menu/content
+  routing. Used by `C_YUI_MAIN`-based apps. New apps route through
+  `C_YUI_SHELL` instead.
 - **Map** (`C_YUI_MAP`) — MapLibre GL map wrapper.
 - **Charts** (`C_YUI_UPLOT`) — uPlot chart wrapper.
 - **JSON viewer** (`C_YUI_JSON_GRAPH`) — JSON visualization with AntV/G6.

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -406,24 +406,48 @@ counter painted by `C_TEST_VIEW`).
 
 ---
 
-## 10. Status and retirement plan
+## 10. Coexistence with `C_YUI_MAIN` / `C_YUI_ROUTING` — no migration planned
 
-This pass closes **every** promise of the original design. What remains
-are the two historical consumers (`C_YUI_MAIN` and `C_YUI_ROUTING`)
-still used elsewhere inside `lib-yui`:
+This pass closes **every** promise of the original design.
+`C_YUI_MAIN` and `C_YUI_ROUTING` are **not** scheduled for removal:
+they keep being shipped and supported alongside the new shell.
 
-### Implemented ✓
+### Which one to use
+
+- **New GUIs → `C_YUI_SHELL` + `C_YUI_NAV`.** Declarative config,
+  routed stages, drawer overlay, focus-trap, hot-swap i18n, the new
+  modal/notification helpers (`yui_shell_show_*` / `yui_shell_confirm_*`,
+  see `TODO.md` §4).
+- **Existing GUIs → keep `C_YUI_MAIN` + `C_YUI_ROUTING`.** Switching
+  is opt-in, not mandated. If an app already works on top of the
+  legacy stack, leave it alone.
+
+The two stacks coexist and **do not interoperate** in the same DOM —
+do not import `c_yui_main.css` and `c_yui_shell.css` together (see
+§11 below). One app picks one stack and stays there.
+
+### Drift policy between the two stacks
+
+Bug reports against `display_*`, `get_yes*`, `get_ok` (legacy) are
+fixed on the legacy implementation only. The new shell helpers
+(`yui_shell_show_*`, `yui_shell_confirm_*`) **do not back-port**
+those fixes unless the original behaviour was a real feature, not a
+quirk. Conversely, improvements landed on the new shell stay on the
+shell. Treat the two APIs as parallel — same intent, separate code.
+
+### Implemented ✓ in this pass
 
 - Zones + `show_on` with the operators `>=`, `<=`, `<`, `>`,
   enumeration, and `|`. Pure parser, unit-tested (`npm test`).
 - Automatic inference of the `main` stage from `"host":
   "stage.<name>"`.
 - All 6 menu layouts (`vertical`, `icon-bar`, `tabs`, `drawer`,
-  `submenu`, `accordion`), with auto-expansion of the active branch on
-  accordion when the route changes.
+  `submenu`, `accordion`), with auto-expansion of the active branch
+  on accordion when the route changes.
 - Off-canvas drawer: mounted on the `overlay` layer (not inside the
   zone grid), closed on backdrop click and on `Escape`, public API
-  `yui_shell_{open,close,toggle}_drawer`.
+  `yui_shell_{open,close,toggle}_drawer`, focus-trap with
+  Tab/Shift-Tab cycling and focus restoration.
 - `lifecycle: eager | keep_alive | lazy_destroy`, with the first one
   preinstantiating the views at startup.
 - **Declarative toolbar** (`toolbar.items[]` with `navigate`,
@@ -431,7 +455,8 @@ still used elsewhere inside `lib-yui`:
 - Single router: the nav publishes `EV_NAV_CLICKED`, the shell
   routes.
 - i18n hook `translate: (key) => string` applied to labels and
-  `aria-label`.
+  `aria-label`, plus `yui_shell_set_translate` for hot-swap of the
+  resolver at runtime.
 - Accessibility: `role="navigation"` on navs, `role="dialog"` +
   `aria-modal` on drawers, `aria-expanded` / `aria-controls` on the
   accordion, `aria-disabled` + `tabindex="-1"` on disabled items,
@@ -441,32 +466,11 @@ still used elsewhere inside `lib-yui`:
 - Hard contract: when a view does not expose `$container`, the shell
   logs an error and destroys the half-built gobj.
 
-### Retirement plan for `C_YUI_MAIN` / `C_YUI_ROUTING`
+### If the migration decision is ever revisited
 
-These are the blockers before either of them can be deleted:
-
-1. **Modals and notifications** — `C_YUI_MAIN` exposes `display_*`,
-   the volatile-dialog manager and toasts. The shell already creates
-   the `modal`, `notification`, and `loading` layers in `build_ui`,
-   but there is still no declarative API on top of them. First step:
-   move `display_error`, `display_info`, `display_confirm` to shell
-   helpers that paint into `layers.notification` / `layers.modal`.
-2. **Widget grid / `C_YUI_MAIN.layout`** — review which `lib-yui`
-   consumers use it (`grep register_c_yui_main`). Each one switches
-   to the shell by declaring its zones.
-3. **`C_YUI_ROUTING`** — the hash routing already lives in the shell,
-   but `C_YUI_TABS` and a few other components still use it. It can
-   be retired once each one is rewritten to subscribe to the shell's
-   `EV_ROUTE_CHANGED` instead of `C_YUI_ROUTING`'s `EV_ROUTING_CHANGED`.
-
-Checklist before deleting either gclass:
-
-- [ ] `grep -r register_c_yui_main  kernel/ utils/ yunos/` is empty.
-- [ ] `grep -r register_c_yui_routing kernel/ utils/ yunos/` is empty.
-- [ ] Helpers equivalent to `display_*` are available on top of the
-      shell.
-- [ ] Consumers of `EV_ROUTING_CHANGED` migrated to the shell's
-      `EV_ROUTE_CHANGED`.
+The work needed to retire `C_YUI_MAIN` / `C_YUI_ROUTING` is captured
+as an optional, deferred track in `TODO.md` §8 (sub-tasks 8.1 → 8.4).
+Until that decision is made, do **not** start any of those sub-tasks.
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -4,30 +4,38 @@ Living TODO for the declarative shell refactor on branch
 `claude/refactor-gui-system-qptVn`.  Numbered roughly by dependency
 order; do not skip ahead without reading the rationale on each item.
 
+**Scope decision (2026-04):** existing GUIs will **not** be migrated
+to the new shell.  `C_YUI_MAIN` and `C_YUI_ROUTING` stay shipped and
+supported so legacy apps keep working unchanged.  The new shell
+(`C_YUI_SHELL` + `C_YUI_NAV`) targets **new** GUIs only.  The
+migration of legacy apps is captured as an optional, gated track at
+the end of this file (#8) for whoever decides to take it on later.
+
 The arc this list closes:
 
-> The original review scope (10 findings, 4 blockers) is **done**.  What
-> remains is the migration plan documented in [`SHELL.md` §10](./SHELL.md)
-> ("Status and retirement plan") plus the polish items spilled out of
-> the iteration.  When this list is empty, `C_YUI_MAIN` and
-> `C_YUI_ROUTING` can be deleted from `lib-yui`.
+> The original review scope (10 findings, 4 blockers) is **done**.
+> What remains is the polish needed to make the new shell a
+> first-class option for new GUIs (modals, escape stack, secondary-
+> nav generalisation, e2e smoke), plus the release cut on top of
+> which new apps can ride.  Legacy `C_YUI_MAIN` / `C_YUI_ROUTING`
+> are explicitly out of scope here.
 
-Order rationale (revised after review):
+Order rationale (revised after the "no legacy migration" decision):
 
 - #1 + #2 close the original review scope and let us cut a `7.4.0`
-  release on top of which the migration can ride.
+  release that new GUIs can adopt.
 - #3 (Escape stack) lands **before** #4 (modals) on purpose: any
   modal/popup component will register itself on the stack, retro-
   fitting it after the fact is much more painful.
-- #4 → #5 → #6 are the migration spine: shell-side helpers, then
-  one consumer (`C_YUI_TABS`) end-to-end, then the rest of the
-  inventory.
-- #7 (real-world test on `estadodelaire/gui`) gates #8 (deletion of
-  legacy classes).
-- #9 / #10 are independent improvements that can land at any time
-  but are most useful **before** #6 / #7 (smoke coverage during the
-  risky migration).
-- #11 closes the branch.
+- #4 (Modal/notification API) makes the new shell self-sufficient
+  for new GUIs — they don't need to import `c_yui_main.js` for
+  toasts/dialogs.
+- #5 (secondary-nav generalisation) removes the `menu.primary`-only
+  limitation so new GUIs with multiple primary-style menus work.
+- #6 (Playwright e2e) gates regressions on the shell itself.
+- #7 closes the branch.
+- #8 is the **optional** legacy-migration track, kept here as a
+  reference checklist if the decision is ever revisited.
 
 ---
 
@@ -80,10 +88,10 @@ publish:
       drawer staying open after navigation, vite alias matching
       sub-paths, missing drawer helper re-exports, ugly
       `secondary.<id>` heading via the new `nav_label` attribute.
-    - **Note**: `C_YUI_MAIN` and `C_YUI_ROUTING` are still shipped
-      and not deprecated yet.  Migration is tracked in
-      `kernel/js/lib-yui/TODO.md` and `kernel/js/lib-yui/SHELL.md`
-      §10.
+    - **Note**: `C_YUI_MAIN` and `C_YUI_ROUTING` remain shipped and
+      fully supported.  The new shell is the recommended path for
+      **new** GUIs only; legacy GUIs keep using the old classes.
+      Optional migration tasks tracked in `TODO.md` §8.
 
 **Done when:** version bumped, CHANGELOG entry merged.
 
@@ -108,7 +116,7 @@ stack.
 - Refactor `open_drawer` / `close_drawer` / `toggle_drawer` to use
   the stack instead of calling `close_all_drawers` directly.
 - Document the order in `SHELL.md` §11 and add a regression test in
-  the e2e suite once #10 is up.
+  the e2e suite once #6 is up.
 
 **Done when:** with a modal open over a drawer, Escape closes the
 modal first; second Escape closes the drawer.
@@ -119,10 +127,13 @@ modal first; second Escape closes the drawer.
 
 Today the shell creates `priv.layers.modal`, `priv.layers.notification`
 and `priv.layers.loading` in `build_ui` but exposes no API for them.
-The legacy entry points still live in `c_yui_main.js`:
-`display_volatil_modal`, `display_info_message`,
-`display_warning_message`, `display_error_message`,
-`get_yesnocancel`, `get_yesno`, `get_ok`.
+New GUIs built on the shell should be able to render modals and
+toasts **without** importing `c_yui_main.js`.
+
+The legacy entry points (`display_volatil_modal`, `display_info_message`,
+`display_warning_message`, `display_error_message`, `get_yesnocancel`,
+`get_yesno`, `get_ok`) stay in `c_yui_main.js` for legacy apps and
+are **not** removed.  The new shell exposes a parallel API instead.
 
 - **Generalise** the drawer focus-trap (`activate_focus_trap` /
   `release_focus_trap` / `FOCUSABLE_SELECTOR`) into a generic
@@ -131,149 +142,38 @@ The legacy entry points still live in `c_yui_main.js`:
   `shell_show_on.js`.  Add a small `tests/shell_focus_trap.test.mjs`
   using happy-dom (or a tiny stub) so the runner gets its second
   client.
-- Port each `display_*` / `get_yes*` helper to a shell-level function
-  that paints into the corresponding layer.  Keep the same exported
-  names (drop-in replacement) and re-export them from `index.js`.
+- Add shell-level helpers — distinct names from the legacy ones to
+  avoid ambiguity for consumers that might import both.  Naming
+  convention: `yui_shell_show_*` for non-blocking notifications
+  (no answer expected from the user), `yui_shell_confirm_*` for
+  blocking dialogs (the helper resolves with the user's choice).
+    - Non-blocking: `yui_shell_show_modal`, `yui_shell_show_info`,
+      `yui_shell_show_warning`, `yui_shell_show_error`.
+    - Blocking: `yui_shell_confirm_yesnocancel`,
+      `yui_shell_confirm_yesno`, `yui_shell_confirm_ok` (single OK
+      button — still a dialog the user has to dismiss, hence
+      `confirm_*`, not `show_*`).
+  Re-export from `index.js`.
 - Reuse Bulma's `.modal` / `.notification` markup verbatim for visual
   parity with the legacy implementation.
 - Each modal/popup that grabs focus must register a close handler on
   the Escape stack from #3.
 - Add a smoke entry in `test-app/app_config.json`: a toolbar item
-  that fires `display_info_message("Hello")` so the toast renders
-  without any view doing it.
+  that fires `yui_shell_show_info(shell, "Hello")` so the toast
+  renders without any view doing it.
 
-**Done when:** every existing call to `display_*` / `get_yes*` from
-`c_yui_main.js` can be served from the shell, and `c_yui_main.js` is
-no longer the authority for modals/toasts.
+**Drift policy** between the new helpers and the legacy `display_*`
+/ `get_yes*` / `get_ok` is documented in
+[`SHELL.md` §10](./SHELL.md): legacy bug fixes are not back-ported,
+shell improvements stay on the shell.
 
----
-
-## 5. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
-
-`C_YUI_TABS.ac_show` / `ac_hide` listen to `EV_ROUTING_CHANGED` of
-`C_YUI_ROUTING`.  Move that subscription to the shell's
-`EV_ROUTE_CHANGED`:
-
-- Add an attr `shell` (DTP_POINTER, optional) on `C_YUI_TABS`.
-- In `mt_start`, if `shell` is set: `gobj_subscribe_event(shell,
-  "EV_ROUTE_CHANGED", {}, gobj)`.  In `mt_stop`: unsubscribe.
-- Keep the legacy `C_YUI_ROUTING` path as a fallback when `shell` is
-  not set, so the migration can land before consumers are converted.
-  Mark the fallback `// transitional — remove after TODO #6` and link
-  to this TODO.
-- Add a small test-app stage that uses tabs to confirm.
-
-**Done when:** the test-app + `estadodelaire/gui` (after #7) work
-without registering `C_YUI_ROUTING`.
+**Done when:** new GUIs can render every modal/toast variant through
+shell helpers without importing `c_yui_main.js`; the legacy helpers
+remain untouched.
 
 ---
 
-## 6. Inventory and migrate the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
-
-```
-grep -r register_c_yui_main      kernel/ utils/ yunos/
-grep -r register_c_yui_routing   kernel/ utils/ yunos/
-grep -rl EV_ROUTING_CHANGED      kernel/ utils/ yunos/
-grep -rlE 'display_(error|info|warning|volatil)|get_yes|get_ok' kernel/ utils/ yunos/
-```
-
-For every hit that is not the migration itself, open a sub-task here.
-Likely consumers inside `lib-yui`:
-
-- `c_yui_treedb_topics.js`
-- `c_yui_treedb_topic_with_form.js`
-- `c_yui_treedb_graph.js`
-- `c_g6_nodes_tree.js`
-- `c_yui_form.js` (uses `display_*`)
-- `yui_dev.js` (developer panel)
-
-Each consumer:
-
-- Replace `EV_ROUTING_CHANGED` subscription with `EV_ROUTE_CHANGED`
-  (via the shell, see #5).
-- Replace `display_*` / `get_yes*` calls with the shell-helper
-  version (#4).
-- Drop the dependency on the old gclasses from its imports.
-
-**Done when:** the four `grep`s above return empty inside `lib-yui`
-itself.
-
----
-
-## 7. Migrate `estadodelaire/gui` to the shell — first real-world test
-
-The companion repo `artgins/estadodelaire` is the canonical app on
-top of `lib-yui`.  Replace its bootstrap:
-
-- `gui/src/main.js`: drop `register_c_yui_main / register_c_yui_routing`,
-  add `register_c_yui_shell / register_c_yui_nav` and registrations
-  for every `c_ui_*` gclass.
-- `gui/src/c_yuneta_gui.js`: replace its custom shell wiring with a
-  declarative `app_config.json` next to it.  Each `c_ui_*` gclass
-  becomes a `target.gclass` with the appropriate `lifecycle`:
-    - `c_ui_alarms` → `keep_alive` (subscribes to live data).
-    - `c_ui_device_sonda` / `c_ui_device_termod` → `keep_alive` per
-      device id.
-    - `c_ui_historical_chart` → `lazy_destroy` (heavy, infrequent).
-    - `c_ui_monitoring` / `c_ui_monitoring_group` → `keep_alive`.
-    - `c_ui_todo` / `c_yui_gobj_tree_js` → `lazy_destroy`.
-- **Verify CSS class scope.**  `c_yui_shell.css` defines generic
-  selectors (`.yui-toolbar`, `.yui-stage > *`, `.yui-zone-center > *`,
-  `.yui-nav-iconbar .yui-nav-item.is-active`, etc.).  Confirm none
-  of them collide with classes used by the `c_ui_*` views.  If they
-  do, add the `.yui-shell` ancestor selector to scope shell rules.
-- Verify on real screen sizes:
-    - Mobile (<769): primary as `icon-bar` at `bottom`, submenu as
-      `tabs` at `top-sub`, drawer for the user/account menu.
-    - Tablet (769-1023): same primary placement + toolbar appears at
-      `top`.
-    - Desktop (≥1024): primary at `left` (vertical), submenu at
-      `right` (vertical), full toolbar.
-- Confirm the live language switch using existing locales/flags
-  (`gui/src/locales/`).
-- **If a feature gap appears** (a layout the current GUI does that
-  the new shell doesn't), capture it as a follow-up here **before
-  continuing**.  Do not patch around it ad-hoc inside `gui/`.
-
-**Done when:** `cd gui && npm run dev` boots EstadoDelAire on the new
-shell and the smoke flows (alarms, monitoring, history) work.
-
----
-
-## 8. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
-
-Gated on tasks #4, #5, #6 and #7.  The retirement checklist
-documented in `SHELL.md` §10 must be empty:
-
-```
-grep -r register_c_yui_main      kernel/ utils/ yunos/   # empty
-grep -r register_c_yui_routing   kernel/ utils/ yunos/   # empty
-grep -rl EV_ROUTING_CHANGED      kernel/ utils/ yunos/   # empty
-grep -rlE 'display_(error|info|warning|volatil)|get_yes|get_ok' kernel/ utils/ yunos/  # empty
-```
-
-Then:
-
-- Delete `src/c_yui_main.js`, `src/c_yui_main.css`,
-  `src/c_yui_routing.js`, `src/c_yui_routing.css`.
-- Remove their exports from `index.js`.
-- Drop `import "@yuneta/lib-yui/src/c_yui_main.css"` /
-  `c_yui_routing.css` from any remaining `main.js` (test-app should
-  not need them).
-- Update `SHELL.md` §11 to remove the "Do not import `c_yui_main.css`
-  and `c_yui_shell.css` together" item (and renumber).  Update
-  `SHELL.md` §10 to mark the retirement plan as completed.
-- Update `README.md` of `lib-yui` to drop the `C_YUI_MAIN` /
-  `C_YUI_ROUTING` mentions.
-- Bump `lib-yui` to `7.5.0` (breaking change).  Add CHANGELOG entry
-  with the removal and link to this TODO.
-
-**Done when:** `lib-yui` no longer ships either gclass and no
-consumer inside the org references them.
-
----
-
-## 9. Generalise the secondary-nav loop beyond `menu.primary`
+## 5. Generalise the secondary-nav loop beyond `menu.primary`
 
 `instantiate_menus()` in `c_yui_shell.js` walks only
 `menus.primary.items[*].submenu` to build level-2 navs.  See
@@ -295,19 +195,15 @@ with submenus and both render their secondary navs correctly.
 
 ---
 
-## 10. End-to-end smoke with Playwright
+## 6. End-to-end smoke with Playwright
 
 Today there is **no automated smoke** of the shell — only the 13
 `shell_show_on` parser tests run in CI.  Add a thin Playwright
 suite.
 
-**Land at least the "boot + navigate primary" subset BEFORE #6**
-so the migration of consumers in #6 is caught instantly when it
-breaks something.  The full catalogue can grow incrementally.
-
 - Boot the test-app via `vite preview` against the built bundle.
 - Two presets, two browsers (chromium + firefox at minimum).
-- Tests, in order of priority (the first two are the gate for #6):
+- Tests, in order of priority:
     1. **boot**: `/dash/ov` renders, the card title is "Overview".
     2. **navigation**: clicking each primary item changes the
        active highlight and the centre stage.
@@ -333,13 +229,13 @@ PR.
 
 ---
 
-## 11. Open PR + run `/ultrareview` before merging to `main`
+## 7. Open PR + run `/ultrareview` before merging to `main`
 
 Convention: feature branches are independently reviewed before
 they land.
 
 - Open the PR `claude/refactor-gui-system-qptVn → main` once tasks
-  #1–#10 are at a place where merging is desirable (does not
+  #1–#6 are at a place where merging is desirable (does not
   require every task to be done — at minimum #1 + #2 close the
   original review scope).
 - The user runs `/ultrareview <PR#>` for a multi-agent independent
@@ -351,3 +247,102 @@ they land.
 - Delete the feature branch after merge.
 
 **Done when:** the PR is merged and the branch is deleted.
+
+---
+
+## 8. (Optional, deferred) Migrate legacy GUIs off `C_YUI_MAIN` / `C_YUI_ROUTING`
+
+> **Status: not planned.**  Captured here as a reference checklist
+> for whoever decides to take it on later.  Until that decision is
+> made, `C_YUI_MAIN` and `C_YUI_ROUTING` stay shipped and supported.
+> Do **not** start any sub-task below without an explicit go-ahead.
+
+The work needed if the decision is reversed:
+
+### 8.1. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
+
+`C_YUI_TABS.ac_show` / `ac_hide` listen to `EV_ROUTING_CHANGED` of
+`C_YUI_ROUTING`.  Move that subscription to the shell's
+`EV_ROUTE_CHANGED`:
+
+- Add an attr `shell` (DTP_POINTER, optional) on `C_YUI_TABS`.
+- In `mt_start`, if `shell` is set: `gobj_subscribe_event(shell,
+  "EV_ROUTE_CHANGED", {}, gobj)`.  In `mt_stop`: unsubscribe.
+- Keep the legacy `C_YUI_ROUTING` path as a fallback when `shell` is
+  not set, so the migration can land before consumers are converted.
+- Add a small test-app stage that uses tabs to confirm.
+
+### 8.2. Inventory the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
+
+```
+grep -r register_c_yui_main      kernel/ utils/ yunos/
+grep -r register_c_yui_routing   kernel/ utils/ yunos/
+grep -rl EV_ROUTING_CHANGED      kernel/ utils/ yunos/
+grep -rlE 'display_(error|info|warning|volatil)|get_yes|get_ok' kernel/ utils/ yunos/
+```
+
+Likely consumers inside `lib-yui`:
+
+- `c_yui_treedb_topics.js`
+- `c_yui_treedb_topic_with_form.js`
+- `c_yui_treedb_graph.js`
+- `c_g6_nodes_tree.js`
+- `c_yui_form.js` (uses `display_*`)
+- `yui_dev.js` (developer panel)
+
+For each consumer:
+
+- Replace `EV_ROUTING_CHANGED` subscription with `EV_ROUTE_CHANGED`
+  via the shell (see 8.1).
+- Replace `display_*` / `get_yes*` calls with the shell-helper
+  version (#4: `yui_shell_show_*` / `yui_shell_confirm_*`).
+- Drop the dependency on the old gclasses from imports.
+
+### 8.3. Migrate `estadodelaire/gui` to the shell — first real-world test
+
+The companion repo `artgins/estadodelaire` is the canonical app on
+top of `lib-yui`.  Replace its bootstrap:
+
+- `gui/src/main.js`: drop `register_c_yui_main / register_c_yui_routing`,
+  add `register_c_yui_shell / register_c_yui_nav` and registrations
+  for every `c_ui_*` gclass.
+- `gui/src/c_yuneta_gui.js`: replace its custom shell wiring with a
+  declarative `app_config.json` next to it.  Each `c_ui_*` gclass
+  becomes a `target.gclass` with the appropriate `lifecycle`:
+    - `c_ui_alarms` → `keep_alive`.
+    - `c_ui_device_sonda` / `c_ui_device_termod` → `keep_alive` per
+      device id.
+    - `c_ui_historical_chart` → `lazy_destroy`.
+    - `c_ui_monitoring` / `c_ui_monitoring_group` → `keep_alive`.
+    - `c_ui_todo` / `c_yui_gobj_tree_js` → `lazy_destroy`.
+- **Verify CSS class scope.**  `c_yui_shell.css` defines generic
+  selectors (`.yui-toolbar`, `.yui-stage > *`, `.yui-zone-center > *`,
+  `.yui-nav-iconbar .yui-nav-item.is-active`, etc.).  Confirm none
+  collide with classes used by the `c_ui_*` views.  If they do, add
+  the `.yui-shell` ancestor selector to scope shell rules.
+- Verify on real screen sizes (mobile / tablet / desktop) per the
+  layout matrix in `SHELL.md`.
+- Confirm the live language switch using existing locales/flags
+  (`gui/src/locales/`).
+- **If a feature gap appears**, capture it as a follow-up here
+  **before continuing**.  Do not patch around it ad-hoc inside
+  `gui/`.
+
+### 8.4. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
+
+Gated on 8.1, 8.2, 8.3.  All four greps above must return empty.
+
+- Delete `src/c_yui_main.js`, `src/c_yui_main.css`,
+  `src/c_yui_routing.js`, `src/c_yui_routing.css`.
+- Remove their exports from `index.js`.
+- Drop `import "@yuneta/lib-yui/src/c_yui_main.css"` /
+  `c_yui_routing.css` from any remaining `main.js`.
+- Update `SHELL.md` §11 to remove the "Do not import `c_yui_main.css`
+  and `c_yui_shell.css` together" item (and renumber).
+- Update `README.md` of `lib-yui` to drop the `C_YUI_MAIN` /
+  `C_YUI_ROUTING` mentions.
+- Bump `lib-yui` to `8.0.0` (breaking change).  Add CHANGELOG entry
+  with the removal and link to this TODO.
+
+**Done when (8 as a whole):** `lib-yui` no longer ships either
+gclass and no consumer inside the org references them.

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -25,7 +25,7 @@
 /* global window, document */
 
 import {
-    SDATA, SDATA_END, data_type_t, event_flag_t,
+    SDATA, SDATA_END, data_type_t, event_flag_t, gclass_flag_t,
     gclass_create, log_error, log_warning,
     gobj_create, gobj_destroy,
     gobj_start, gobj_stop,
@@ -862,11 +862,15 @@ function handle_toolbar_action(gobj, item)
                 close_drawer(gobj, menu_id);
             }
             else {
-                 { toggle_drawer(gobj, menu_id); }
+                toggle_drawer(gobj, menu_id);
             }
             break;
         }
         case "event":
+            /*  Publish whatever event name the JSON requested.  The shell
+             *  is created with gcflag_no_check_output_events so it acts as
+             *  an intermediate that forwards arbitrary user-defined events
+             *  without each app having to extend our event_types table. */
             if(!empty_string(action.event)) {
                 gobj_publish_event(gobj, action.event, action.kw || {});
             }
@@ -1212,10 +1216,13 @@ function create_gclass(gclass_name)
         event_types,
         states,
         gmt,
-        0,
+        0,                          /* lmt */
         attrs_table,
         PRIVATE_DATA,
-        0, 0, 0, 0
+        0,                          /* authz_table */
+        0,                          /* command_table */
+        0,                          /* s_user_trace_level */
+        gclass_flag_t.gcflag_no_check_output_events
     );
     if(!__gclass__) {
         return -1;

--- a/kernel/js/lib-yui/test-app/README.md
+++ b/kernel/js/lib-yui/test-app/README.md
@@ -44,6 +44,14 @@ Between both presets every one of the six supported layouts runs at least once.
   off-canvas quick menu. Click the backdrop or press `Escape` to close it.
 - **Toolbar** is fully declarative — `burger` triggers a drawer, `home`
   navigates, `help` navigates and sits on the right (`align: "end"`).
+- **Live i18n**: the `ES/EN` button on the right of the toolbar fires
+  `EV_TOGGLE_LANGUAGE` (a custom user event); a tiny side controller
+  (`C_TEST_LANG`) listens for it and calls `yui_shell_set_translate`
+  with one of two trivial dictionaries. Click it and watch every menu
+  label, the secondary-nav heading, and every toolbar `<button>` label
+  swap to Spanish, then back to English. The active item highlight
+  is preserved across the swap because the shell re-publishes
+  `EV_ROUTE_CHANGED`.
 
 ## What to look at (accordion preset)
 
@@ -55,6 +63,18 @@ Open `?preset=accordion`:
   `aria-expanded` / `aria-controls` update accordingly.
 - Keyboard: `Tab` walks the items, `Enter` / `Space` activates them, and
   `:focus-visible` outlines the active control.
+
+## Caveat — `yui_shell_set_translate` and the active highlight
+
+`yui_shell_set_translate` re-publishes `EV_ROUTE_CHANGED` so navs
+re-mark the active item under the new labels. That re-publish is
+gated on `current_route` being non-empty: if you click the ES/EN
+button **before** the first navigation has succeeded (e.g. the hash
+is empty and there is no `default_route`), the navs are rebuilt
+correctly but no highlight appears until you navigate. Production
+configs always have a `default_route`, so this is only visible in
+custom edge cases — surfaced here so it does not surprise
+integrators.
 
 ## Accessibility spot-checks
 
@@ -77,3 +97,7 @@ Open `?preset=accordion`:
   + drawer).
 - `src/c_test_view.js` — minimal view gobj exposing `$container`; used
   as the `target.gclass` for every menu item.
+- `src/c_test_lang.js` — small CHILD gobj that subscribes to the
+  shell's `EV_TOGGLE_LANGUAGE` and applies a dictionary via
+  `yui_shell_set_translate`. Canonical pattern for any app that needs
+  to react to custom toolbar events.

--- a/kernel/js/lib-yui/test-app/src/app_config.json
+++ b/kernel/js/lib-yui/test-app/src/app_config.json
@@ -41,6 +41,14 @@
                 "name": "Help",
                 "align": "end",
                 "action": { "type": "navigate", "route": "/help" }
+            },
+            {
+                "id": "lang",
+                "icon": "icon-translate",
+                "name": "ES/EN",
+                "align": "end",
+                "aria_label": "Toggle language",
+                "action": { "type": "event", "event": "EV_TOGGLE_LANGUAGE" }
             }
         ]
     },

--- a/kernel/js/lib-yui/test-app/src/app_config_accordion.json
+++ b/kernel/js/lib-yui/test-app/src/app_config_accordion.json
@@ -25,7 +25,11 @@
               "aria_label": "Open quick menu",
               "action": { "type": "drawer", "op": "toggle", "menu_id": "quick" } },
             { "id": "home",   "icon": "icon-home", "name": "Home",
-              "action": { "type": "navigate", "route": "/dash/ov" } }
+              "action": { "type": "navigate", "route": "/dash/ov" } },
+            { "id": "lang",   "icon": "icon-translate", "name": "ES/EN",
+              "align": "end",
+              "aria_label": "Toggle language",
+              "action": { "type": "event", "event": "EV_TOGGLE_LANGUAGE" } }
         ]
     },
 

--- a/kernel/js/lib-yui/test-app/src/c_test_lang.js
+++ b/kernel/js/lib-yui/test-app/src/c_test_lang.js
@@ -1,0 +1,266 @@
+/***********************************************************************
+ *          c_test_lang.js
+ *
+ *      C_TEST_LANG — Language toggle controller for the test app.
+ *      Subscribes to the shell's `EV_TOGGLE_LANGUAGE` (published by the
+ *      toolbar item with `action.type:"event"`), flips between two
+ *      trivial dictionaries on each click, and applies the new
+ *      resolver via `yui_shell_set_translate`.
+ *
+ *      This is the canonical pattern for any app that needs to react
+ *      to custom toolbar events: a small CHILD gobj that declares the
+ *      event in its FSM and subscribes to the shell.
+ *
+ *          Copyright (c) 2026, ArtGins.
+ *          All Rights Reserved.
+ ***********************************************************************/
+import {
+    SDATA, SDATA_END, data_type_t, event_flag_t,
+    gclass_create, log_error,
+    gobj_parent,
+    gobj_read_attr, gobj_read_pointer_attr, gobj_write_attr,
+    gobj_subscribe_event,
+} from "@yuneta/gobj-js";
+
+import {
+    yui_shell_set_translate,
+} from "@yuneta/lib-yui";
+
+
+/***************************************************************
+ *              Constants
+ ***************************************************************/
+const GCLASS_NAME = "C_TEST_LANG";
+
+/*  Two minimal dictionaries — keys are the canonical English label
+ *  strings the test-app uses in its app_config*.json.
+ *
+ *  Real apps would resolve via i18next / similar; here we keep it
+ *  inline so the harness has no extra dependency. */
+const DICT_EN = {};   /*  Identity for English. */
+const DICT_ES = {
+    "Dashboard":         "Panel",
+    "Overview":          "Resumen",
+    "Devices":           "Dispositivos",
+    "Alerts":            "Alertas",
+    "Reports":           "Informes",
+    "Daily":             "Diario",
+    "Monthly":           "Mensual",
+    "Settings":          "Ajustes",
+    "Help":              "Ayuda",
+    "Help (eager)":      "Ayuda (eager)",
+    "Daily reports":     "Informes diarios",
+    "Monthly reports":   "Informes mensuales",
+    "Quick: Overview":   "Rápido: Resumen",
+    "Quick: Alerts":     "Rápido: Alertas",
+    "Quick: Settings":   "Rápido: Ajustes",
+    "Home":              "Inicio",
+    "Open menu":         "Abrir menú",
+    "Open quick menu":   "Abrir menú rápido",
+    "ES/EN":             "EN/ES",
+    "App toolbar":       "Barra de herramientas",
+};
+
+
+/***************************************************************
+ *              Attrs
+ ***************************************************************/
+const attrs_table = [
+SDATA(data_type_t.DTP_POINTER,  "subscriber",  0,  null,  "Subscriber of output events"),
+
+SDATA(data_type_t.DTP_POINTER,  "shell",       0,  null,  "C_YUI_SHELL gobj to drive translate on"),
+SDATA(data_type_t.DTP_BOOLEAN,  "is_es",       0,  false, "Current language flag (true = ES, false = EN)"),
+SDATA_END()
+];
+
+let PRIVATE_DATA = {};
+let __gclass__ = null;
+
+
+
+
+                    /******************************
+                     *      Framework Methods
+                     ******************************/
+
+
+
+
+/***************************************************************
+ *          Framework Method: Create
+ ***************************************************************/
+function mt_create(gobj)
+{
+    /*
+     *  CHILD subscription model
+     */
+    let subscriber = gobj_read_pointer_attr(gobj, "subscriber");
+    if(!subscriber) {
+        subscriber = gobj_parent(gobj);
+    }
+    gobj_subscribe_event(gobj, null, {}, subscriber);
+}
+
+/***************************************************************
+ *          Framework Method: Start
+ ***************************************************************/
+function mt_start(gobj)
+{
+    let shell = gobj_read_pointer_attr(gobj, "shell");
+    if(!shell) {
+        log_error("C_TEST_LANG: shell attr not set, language toggle disabled");
+        return;
+    }
+    /*  Subscribe to the toolbar's user-defined event.  The shell is
+     *  built with gcflag_no_check_output_events so it forwards any
+     *  event name from the JSON without us having to extend its
+     *  event_types table. */
+    try {
+        gobj_subscribe_event(shell, "EV_TOGGLE_LANGUAGE", {}, gobj);
+    } catch(e) {
+        log_error(`C_TEST_LANG: subscribe to shell EV_TOGGLE_LANGUAGE failed: ${e}`);
+    }
+}
+
+/***************************************************************
+ *          Framework Method: Stop
+ ***************************************************************/
+function mt_stop(gobj)
+{
+}
+
+/***************************************************************
+ *          Framework Method: Destroy
+ ***************************************************************/
+function mt_destroy(gobj)
+{
+}
+
+
+
+
+                    /***************************
+                     *      Local Methods
+                     ***************************/
+
+
+
+
+/***************************************************************
+ *  Build a translate function backed by `dict`: returns the
+ *  mapped value when present, falls back to the input key
+ *  (so untranslated labels still display).
+ ***************************************************************/
+function make_translator(dict)
+{
+    return function(key) {
+        if(typeof key !== "string") {
+            return key;
+        }
+        if(Object.prototype.hasOwnProperty.call(dict, key)) {
+            return dict[key];
+        }
+        return key;
+    };
+}
+
+
+
+
+                    /***************************
+                     *      Actions
+                     ***************************/
+
+
+
+
+/***************************************************************
+ *  Toolbar fired EV_TOGGLE_LANGUAGE — flip the language flag and
+ *  hot-swap the shell's translate hook.  The shell takes care of
+ *  rebuilding every nav and the toolbar.
+ ***************************************************************/
+function ac_toggle_language(gobj, event, kw, src)
+{
+    let shell = gobj_read_pointer_attr(gobj, "shell");
+    if(!shell) {
+        return 0;
+    }
+    let is_es = !gobj_read_attr(gobj, "is_es");
+    gobj_write_attr(gobj, "is_es", is_es);
+    let dict = is_es ? DICT_ES : DICT_EN;
+    yui_shell_set_translate(shell, make_translator(dict));
+    return 0;
+}
+
+
+
+
+/***************************************************************
+ *              FSM
+ ***************************************************************/
+/*---------------------------------------------*
+ *          Global methods table
+ *---------------------------------------------*/
+const gmt = {
+    mt_create:  mt_create,
+    mt_start:   mt_start,
+    mt_stop:    mt_stop,
+    mt_destroy: mt_destroy
+};
+
+/***************************************************************
+ *          Create the GClass
+ ***************************************************************/
+function create_gclass(gclass_name)
+{
+    if(__gclass__) {
+        log_error(`GClass ALREADY created: ${gclass_name}`);
+        return -1;
+    }
+
+    /*---------------------------------------------*
+     *          States
+     *---------------------------------------------*/
+    const states = [
+        ["ST_IDLE", [
+            ["EV_TOGGLE_LANGUAGE", ac_toggle_language, null]
+        ]]
+    ];
+
+    /*---------------------------------------------*
+     *          Events
+     *---------------------------------------------*/
+    const event_types = [
+        ["EV_TOGGLE_LANGUAGE", 0]
+    ];
+
+    __gclass__ = gclass_create(
+        gclass_name,
+        event_types,
+        states,
+        gmt,
+        0,                          /* lmt */
+        attrs_table,
+        PRIVATE_DATA,
+        0,                          /* authz_table */
+        0,                          /* command_table */
+        0,                          /* s_user_trace_level */
+        0                           /* gclass_flag */
+    );
+
+    if(!__gclass__) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/***************************************************************
+ *          Register GClass
+ ***************************************************************/
+function register_c_test_lang()
+{
+    return create_gclass(GCLASS_NAME);
+}
+
+export { register_c_test_lang };

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -20,6 +20,8 @@ import {
     gobj_start_up,
     gobj_create_yuno,
     gobj_create_default_service,
+    gobj_create_pure_child,
+    gobj_find_service,
     gobj_start, gobj_play,
     register_c_yuno,
     register_c_timer,
@@ -31,6 +33,7 @@ import {
 } from "@yuneta/lib-yui";
 
 import {register_c_test_view} from "./c_test_view.js";
+import {register_c_test_lang} from "./c_test_lang.js";
 
 import "bulma/css/bulma.css";
 import "@yuneta/lib-yui/src/c_yui_shell.css";
@@ -40,8 +43,9 @@ import app_config_accordion from "./app_config_accordion.json";
 
 
 /*  Identity i18n resolver — shows the SHELL translate hook without
- *  doing any actual translation. Swap for a real resolver to see
- *  labels change across the whole UI. */
+ *  doing any actual translation. The C_TEST_LANG controller swaps
+ *  this for a Spanish dictionary on every click of the toolbar's
+ *  ES/EN button (see c_test_lang.js). */
 function identity_translate(key) {
     return key;
 }
@@ -67,8 +71,9 @@ function main()
     register_c_yui_shell();
     register_c_yui_nav();
 
-    /*  App views  */
+    /*  App views + language controller  */
     register_c_test_view();
+    register_c_test_lang();
 
     gobj_start_up(null, null, null, null, null, null, null);
 
@@ -86,6 +91,17 @@ function main()
             use_hash:  true,
             translate: identity_translate
         },
+        yuno
+    );
+
+    /*  Side controller: subscribes to the shell's EV_TOGGLE_LANGUAGE
+     *  (published by the toolbar's lang button) and swaps the shell's
+     *  translate hook on each click. */
+    let shell = gobj_find_service("shell", false);
+    gobj_create_pure_child(
+        "test_lang",
+        "C_TEST_LANG",
+        { shell: shell },
         yuno
     );
 


### PR DESCRIPTION
## Summary

- Adopts the **no-legacy-migration** scope decision: `C_YUI_MAIN` and `C_YUI_ROUTING` stay shipped and supported; the new `C_YUI_SHELL` is the recommended path for new GUIs only. TODO restructured around 7 active tasks for the new shell + a deferred §8 with the optional retirement track.
- Aligns `SHELL.md` §10 (rewritten as coexistence + drift policy) and `lib-yui/README.md` (new "Which app shell to use?" block) with that decision so the upcoming `7.4.0` doc set is consistent.
- Closes **TODO #1**: ES/EN button in the test-app's toolbar that hot-swaps `yui_shell_set_translate` end to end. Adds a small reusable `C_TEST_LANG` controller (canonical pattern for any app reacting to custom toolbar events) and tags `C_YUI_SHELL` with `gcflag_no_check_output_events` so apps can declare arbitrary toolbar events in JSON without extending the shell's `event_types`.
- Naming convention fixed for the upcoming modal/notification API in TODO #4: `yui_shell_show_*` for non-blocking, `yui_shell_confirm_*` for blocking dialogs (`yui_shell_show_ok` → `yui_shell_confirm_ok`).

Existing GUIs that still rely on `C_YUI_MAIN` / `C_YUI_ROUTING` are **not** affected by any of these changes.

## Commits

- \`967e06874\` — TODO.md: no-legacy-migration scope + naming convention.
- \`3e514358e\` — SHELL.md §10 + README.md align with the coexistence model.
- \`750fd15a3\` — TODO #1: ES/EN button + live-i18n smoke (`C_TEST_LANG` controller, `gcflag_no_check_output_events` on the shell).
- \`abdadcff8\` — \`.jshintrc\` update (companion).

## Test plan

- [ ] \`cd kernel/js/lib-yui && npm test\` is green (13/13 \`shell_show_on\` parser tests).
- [ ] \`cd kernel/js/lib-yui/test-app && npm install && npm run dev\` boots http://localhost:5180 with no console errors.
- [ ] On default preset (\`/\`):
    - [ ] ES/EN button on the right of the toolbar (≥ tablet).
    - [ ] Click flips every menu label, secondary-nav heading, and toolbar button to Spanish; click again flips back.
    - [ ] Active item highlight survives the swap.
- [ ] On \`?preset=accordion\`, the same swap works.
- [ ] No regression on legacy apps that import \`c_yui_main.js\` (none of the touched files affect that stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)