### PR TITLE
lib-yui: canonical i18n (data-i18n + refresh_language)

### DIFF
--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -295,7 +295,6 @@ Recommended default: `keep_alive`.
 | `current_route`  | string      | Read-only: active route                                  |
 | `use_hash`       | bool        | If `true`, syncs `window.location.hash`                  |
 | `mount_element`  | HTMLElement | Where to mount the shell (default `document.body`)       |
-| `translate`      | function    | `(key) => string` — optional i18n; applied to `item.name`, toolbar labels, and `aria-label` |
 | `$container`     | HTMLElement | Shell root                                               |
 
 Published events:
@@ -312,12 +311,27 @@ Public helpers (import from `@yuneta/lib-yui`):
   focus-trap on its panel: `Tab` / `Shift+Tab` cycle inside, and on
   close the focus is restored to whichever element triggered the
   open.
-- `yui_shell_set_translate(shell, fn)` — hot-swap the i18n resolver.
-  Replaces the `translate` attr on the shell and on every nav,
-  rebuilds the nav DOMs and the toolbar, then re-publishes
-  `EV_ROUTE_CHANGED` so navs re-mark the active item under the new
-  labels. Use this to switch languages without destroying the
-  shell.
+
+### Internationalisation
+
+The shell does **not** own i18n. Every translatable text node it
+renders (menu labels, secondary-nav heading, toolbar buttons) is
+emitted with `data-i18n="<canonical English key>"` via
+`createElement2`'s `i18n` attribute. To switch languages, use the
+canonical helper from `@yuneta/gobj-js`:
+
+```js
+import { refresh_language } from "@yuneta/gobj-js";
+import i18next, { t } from "i18next";
+
+i18next.changeLanguage("es");
+refresh_language(shell.$container, t);
+```
+
+This is the same flow `c_yui_main.js` uses in its
+`change_language()`. Apps that already configure i18next get the
+shell labels switched for free; apps without i18next can pass any
+`(key) => string` function as `t`.
 
 ### `C_YUI_NAV`
 
@@ -331,16 +345,15 @@ Published events:
   `navigate_to` directly.
 
 Notable attributes: `menu_items`, `zone`, `layout`, `icon_pos`,
-`show_label`, `level` (`primary` | `secondary`), `shell`, `translate`,
-`nav_label` (human-readable label used by the secondary navs as their
-heading and `aria-label`; the shell fills it from the parent item's
-`name`).
+`show_label`, `level` (`primary` | `secondary`), `shell`,
+`nav_label` (human-readable label used by the secondary navs as
+their heading and `aria-label`; the shell fills it from the parent
+item's `name`).
 
-Public helpers:
-- `yui_nav_rebuild(nav)` — tear the nav's DOM down and re-render it
-  in place, preserving the host parent and the visibility state.
-  Called by `yui_shell_set_translate`; you typically don't need it
-  directly.
+The nav has no `translate` attr — it does not translate text
+itself. Labels are emitted with `data-i18n` and a single
+`refresh_language` call on the shell's `$container` re-translates
+every nav at once.
 
 ---
 
@@ -415,9 +428,10 @@ they keep being shipped and supported alongside the new shell.
 ### Which one to use
 
 - **New GUIs → `C_YUI_SHELL` + `C_YUI_NAV`.** Declarative config,
-  routed stages, drawer overlay, focus-trap, hot-swap i18n, the new
-  modal/notification helpers (`yui_shell_show_*` / `yui_shell_confirm_*`,
-  see `TODO.md` §4).
+  routed stages, drawer overlay, focus-trap, `data-i18n` labels
+  driven by `refresh_language()` (the canonical Yuneta i18n flow),
+  the new modal/notification helpers (`yui_shell_show_*` /
+  `yui_shell_confirm_*`, see `TODO.md` §4).
 - **Existing GUIs → keep `C_YUI_MAIN` + `C_YUI_ROUTING`.** Switching
   is opt-in, not mandated. If an app already works on top of the
   legacy stack, leave it alone.
@@ -454,9 +468,10 @@ shell. Treat the two APIs as parallel — same intent, separate code.
   `drawer`, and `event` actions).
 - Single router: the nav publishes `EV_NAV_CLICKED`, the shell
   routes.
-- i18n hook `translate: (key) => string` applied to labels and
-  `aria-label`, plus `yui_shell_set_translate` for hot-swap of the
-  resolver at runtime.
+- Canonical i18n: every translatable text node carries
+  `data-i18n="<canonical key>"`; apps switch language by calling
+  `refresh_language(shell.$container, t)` from `@yuneta/gobj-js`,
+  the same helper `c_yui_main.js` uses.
 - Accessibility: `role="navigation"` on navs, `role="dialog"` +
   `aria-modal` on drawers, `aria-expanded` / `aria-controls` on the
   accordion, `aria-disabled` + `tabindex="-1"` on disabled items,

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -39,34 +39,25 @@ Order rationale (revised after the "no legacy migration" decision):
 
 ---
 
-## 1. Test-app: language-switch button (smoke for `yui_shell_set_translate`)
+## 1. Test-app: language-switch button (smoke for `refresh_language`)
 
-The hot-swap helper is implemented and exported, but no consumer
-exercises it.  Add a tiny visible loop:
+**Status: DONE** (canonical pattern).
 
-- Add a 4th item to `app_config.json → toolbar.items` (`align: "end"`),
-  e.g. `{ "id": "lang", "icon": "icon-translate", "name": "ES/EN",
-  "action": { "type": "event", "event": "EV_TOGGLE_LANGUAGE" } }`.
-- In `test-app/src/main.js` subscribe to `EV_TOGGLE_LANGUAGE` of the
-  shell; on each fire, flip an in-memory boolean and call
-  `yui_shell_set_translate(shell, fn)` with one of two trivial
-  dictionaries (`"Dashboard" ↔ "Panel"`, `"Reports" ↔ "Informes"`,
-  `"Settings" ↔ "Ajustes"`, etc.).
-- After the click, the menu in `left`/`bottom`, the submenu in
-  `top-sub`/`right`, the heading of the secondary nav (uses
-  `nav_label`) and every toolbar `<button>` label should swap.
-- Update `test-app/README.md` with a "Live i18n" section.
+The shell tags every translatable text node with
+`data-i18n="<canonical key>"` (via `createElement2`'s `i18n` attr).
+Apps switch language by calling
+`refresh_language(shell.$container, t)` from `@yuneta/gobj-js` —
+the same flow `c_yui_main.js` uses in its `change_language()`.
+There is no shell-level translate hook and no DOM rebuild.
 
-**Caveat to document:** `yui_shell_set_translate` only re-publishes
-`EV_ROUTE_CHANGED` when `current_route` is non-empty.  If the user
-clicks the language toggle *before* the first navigation has
-succeeded, navs are rebuilt but the active highlight is empty until
-they navigate.  Surface this in the README so it doesn't surprise
-integrators.
-
-**Done when:** clicking the ES/EN button visibly relabels every menu,
-heading and toolbar button, and the active item highlight survives
-the re-publish of `EV_ROUTE_CHANGED`.
+The test-app exercises this with:
+- A `lang` toolbar item (`align: "end"`) that fires the user-defined
+  `EV_TOGGLE_LANGUAGE` via `action.type:"event"`.  The shell is
+  registered with `gcflag_no_check_output_events` so it forwards the
+  event without the app having to extend its `event_types` table.
+- A small CHILD gobj `C_TEST_LANG` that subscribes to that event and
+  calls `refresh_language(shell.$container, t)` with one of two
+  trivial dictionaries (EN identity / ES map).
 
 ---
 
@@ -77,13 +68,15 @@ publish:
 
 - Bump to `7.4.0`.
 - Add a section to top-level `CHANGELOG.md`:
-    - **Added**: `C_YUI_SHELL`, `C_YUI_NAV`, `shell_show_on` parser with
-      13 `node --test` tests, declarative toolbar, all 6 nav layouts,
-      drawer overlay with focus-trap, hot-swap i18n via
-      `yui_shell_set_translate`, public helpers
+    - **Added**: `C_YUI_SHELL`, `C_YUI_NAV`, `shell_show_on` parser
+      with 13 `node --test` tests, declarative toolbar, all 6 nav
+      layouts, drawer overlay with focus-trap, canonical i18n
+      (every translatable label rendered with
+      `data-i18n="<canonical key>"`; apps switch language by calling
+      `refresh_language(shell.$container, t)` from
+      `@yuneta/gobj-js`), public helpers
       `yui_shell_navigate / yui_shell_open_drawer /
-      yui_shell_close_drawer / yui_shell_toggle_drawer /
-      yui_shell_set_translate / yui_nav_rebuild`.
+      yui_shell_close_drawer / yui_shell_toggle_drawer`.
     - **Fixed (review pass)**: `build_item_index` route collision,
       drawer staying open after navigation, vite alias matching
       sub-paths, missing drawer helper re-exports, ugly

--- a/kernel/js/lib-yui/index.js
+++ b/kernel/js/lib-yui/index.js
@@ -28,9 +28,8 @@ export {
     yui_shell_open_drawer,
     yui_shell_close_drawer,
     yui_shell_toggle_drawer,
-    yui_shell_set_translate,
 } from "./src/c_yui_shell.js";
-export { register_c_yui_nav, yui_nav_rebuild } from "./src/c_yui_nav.js";
+export { register_c_yui_nav } from "./src/c_yui_nav.js";
 
 /*
  *  TreeDB components

--- a/kernel/js/lib-yui/src/c_yui_nav.js
+++ b/kernel/js/lib-yui/src/c_yui_nav.js
@@ -58,7 +58,6 @@ SDATA(data_type_t.DTP_STRING,   "level",         0,  "primary",    "primary|seco
 SDATA(data_type_t.DTP_POINTER,  "shell",         0,  null,         "C_YUI_SHELL gobj (for navigation calls)"),
 SDATA(data_type_t.DTP_POINTER,  "$container",    0,  null,         "Root HTMLElement of this nav"),
 SDATA(data_type_t.DTP_STRING,   "active_route",  0,  "",           "Currently active route"),
-SDATA(data_type_t.DTP_POINTER,  "translate",     0,  null,         "Optional i18n resolver: (key) => string"),
 SDATA(data_type_t.DTP_POINTER,  "priv",          0,  null,         "Private runtime state (click listener, etc.)"),
 SDATA_END()
 ];
@@ -183,7 +182,7 @@ function build_ui(gobj)
         $root.setAttribute("role", "navigation");
         if(!$root.hasAttribute("aria-label")) {
             let label = gobj_read_attr(gobj, "nav_label") || menu_id;
-            $root.setAttribute("aria-label", translate_of(gobj, label));
+            $root.setAttribute("aria-label", label);
         }
     }
 
@@ -192,19 +191,10 @@ function build_ui(gobj)
     gobj_write_attr(gobj, "$container", $root);
 }
 
-function translate_of(gobj, s)
-{
-    let t = gobj_read_attr(gobj, "translate");
-    if(typeof t === "function") {
-        return t(s);
-    }
-    return s;
-}
-
 /************************************************************
  *  Layouts
  *
- *  IMPORTANT: createElement2 destructures node descriptors as
+ *  IMPORTANT 1: createElement2 destructures node descriptors as
  *  [tag, attrs, content, events] positionally, so multiple
  *  children MUST be wrapped in a single array (otherwise the
  *  third sibling would be interpreted as an event-listener map
@@ -212,6 +202,15 @@ function translate_of(gobj, s)
  *
  *      OK:    ["ul", {}, [li1, li2, li3]]
  *      WRONG: ["ul", {}, li1, li2, li3]
+ *
+ *  IMPORTANT 2: every translatable text node carries an `i18n`
+ *  attribute with its canonical (English) key.  createElement2
+ *  maps it to `data-i18n` on the rendered element.  The host app
+ *  changes language by calling `refresh_language(element, t)`
+ *  from `@yuneta/gobj-js`, which walks all `[data-i18n]` and
+ *  re-translates the first text node with `t(key)`.  See the
+ *  legacy `change_language()` in `c_yui_main.js` for the
+ *  canonical pattern.
  ************************************************************/
 function render_vertical(gobj, items)
 {
@@ -255,7 +254,7 @@ function render_tabs(gobj, items)
                 ["i", {class: it.icon, "aria-hidden":"true"}]]);
         }
         if(show_label && !empty_string(it.name)) {
-            children.push(["span", {}, translate_of(gobj, it.name)]);
+            children.push(["span", {i18n: it.name}, it.name]);
         }
         lis.push(
             ["li", {class: "", "data-item-id": it.id, "data-route": it.route || ""},
@@ -284,7 +283,7 @@ function render_drawer(gobj, items)
     wrap.className = "yui-drawer";
     wrap.setAttribute("role", "dialog");
     wrap.setAttribute("aria-modal", "true");
-    wrap.setAttribute("aria-label", translate_of(gobj, menu_id));
+    wrap.setAttribute("aria-label", menu_id);
 
     let back = document.createElement("div");
     back.className = "yui-drawer-backdrop";
@@ -294,7 +293,7 @@ function render_drawer(gobj, items)
     let panel = document.createElement("div");
     panel.className = "yui-drawer-panel";
     panel.setAttribute("role", "navigation");
-    panel.setAttribute("aria-label", translate_of(gobj, menu_id));
+    panel.setAttribute("aria-label", menu_id);
     panel.appendChild(render_vertical(gobj, items));
 
     wrap.appendChild(back);
@@ -313,10 +312,14 @@ function render_submenu(gobj, items)
     for(let it of items) {
         lis.push(item_li(gobj, it, { icon_pos, show_label, stacked: false, compact: true }));
     }
+    let heading_text = nav_label || "—";
+    let heading_attrs = nav_label
+        ? { class: "menu-label", i18n: nav_label }
+        : { class: "menu-label" };
     return createElement2(
         ["aside", {class: "menu p-2"},
             [
-                ["p", {class: "menu-label"}, translate_of(gobj, nav_label) || "—"],
+                ["p", heading_attrs, heading_text],
                 ["ul", {class: "menu-list"}, lis]
             ]
         ]
@@ -338,16 +341,20 @@ function render_accordion(gobj, items)
         let head_id = `yui-acc-head-${acc_id}`;
         let body_id = `yui-acc-body-${acc_id}`;
 
-        let $hdr = createElement2(
-            ["button", {type: "button",
-                        id: head_id,
-                        class: "menu-label yui-accordion-head",
-                        "data-item-id": it.id,
-                        "data-route":   it.route || "",
-                        "aria-expanded": "false",
-                        "aria-controls": body_id},
-                translate_of(gobj, it.name || "")]
-        );
+        let head_text = it.name || "";
+        let head_attrs = {
+            type: "button",
+            id: head_id,
+            class: "menu-label yui-accordion-head",
+            "data-item-id": it.id,
+            "data-route":   it.route || "",
+            "aria-expanded": "false",
+            "aria-controls": body_id
+        };
+        if(!empty_string(head_text)) {
+            head_attrs.i18n = head_text;
+        }
+        let $hdr = createElement2(["button", head_attrs, head_text]);
         $root.appendChild($hdr);
 
         let $ul = createElement2(
@@ -375,13 +382,13 @@ function item_li(gobj, it, opts)
 {
     let { icon_pos, show_label, stacked } = opts;
     let children = [];
-    let label = translate_of(gobj, it.name || "");
+    let label = it.name || "";
 
     let icon_el = !empty_string(it.icon)
         ? ["span", {class: "icon"}, ["i", {class: it.icon, "aria-hidden":"true"}]]
         : null;
     let label_el = (show_label && !empty_string(label))
-        ? ["span", {class: "yui-nav-label"}, label]
+        ? ["span", {class: "yui-nav-label", i18n: label}, label]
         : null;
 
     let a_class = "yui-nav-item";
@@ -426,13 +433,13 @@ function item_li(gobj, it, opts)
 function item_iconbar(gobj, it, opts)
 {
     let { icon_pos, show_label } = opts;
-    let label = translate_of(gobj, it.name || "");
+    let label = it.name || "";
     let icon_el = !empty_string(it.icon)
         ? ["span", {class: "icon is-medium"},
            ["i", {class: it.icon, "aria-hidden":"true"}]]
         : null;
     let label_el = (show_label && !empty_string(label))
-        ? ["span", {class: "yui-nav-label is-size-7"}, label]
+        ? ["span", {class: "yui-nav-label is-size-7", i18n: label}, label]
         : null;
 
     let children = [];
@@ -661,44 +668,4 @@ function register_c_yui_nav()
     return create_gclass(GCLASS_NAME);
 }
 
-/***************************************************************
- *  Rebuild the nav DOM in place.  Used by the shell when the
- *  `translate` attr changes at runtime: the DOM has to be torn
- *  down and re-rendered with the new label resolver, but the
- *  parent and the visibility state must be preserved so the
- *  layout does not flicker.  Active-item highlight is NOT
- *  re-applied here — the shell is expected to re-publish
- *  EV_ROUTE_CHANGED right after, which the nav handles via its
- *  existing ac_route_changed action.
- ***************************************************************/
-function yui_nav_rebuild(nav)
-{
-    let $old = gobj_read_attr(nav, "$container");
-    let priv = gobj_read_attr(nav, "priv");
-    let $parent = ($old && $old.parentNode) || null;
-    let was_hidden = !!($old && $old.classList.contains("is-hidden"));
-    let was_active_drawer = !!($old && $old.classList.contains("is-active"));
-
-    if($old && priv && priv.click_handler) {
-        $old.removeEventListener("click", priv.click_handler);
-    }
-
-    build_ui(nav);
-
-    let $new = gobj_read_attr(nav, "$container");
-    if($parent && $new) {
-        if($old && $old.parentNode === $parent) {
-            $parent.replaceChild($new, $old);
-        } else {
-            $parent.appendChild($new);
-        }
-        if(was_hidden) {
-            $new.classList.add("is-hidden");
-        }
-        if(was_active_drawer) {
-            $new.classList.add("is-active");
-        }
-    }
-}
-
-export { register_c_yui_nav, yui_nav_rebuild };
+export { register_c_yui_nav };

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -41,10 +41,6 @@ import {
     bulma_hidden_class,
 } from "./shell_show_on.js";
 
-import {
-    yui_nav_rebuild,
-} from "./c_yui_nav.js";
-
 /***************************************************************
  *              Constants
  ***************************************************************/
@@ -74,7 +70,6 @@ SDATA(data_type_t.DTP_STRING,   "default_route",  0,  "",    "Fallback route if 
 SDATA(data_type_t.DTP_STRING,   "current_route",  0,  "",    "Current active route"),
 SDATA(data_type_t.DTP_BOOLEAN,  "use_hash",       0,  true,  "Bind navigation to window.location.hash"),
 SDATA(data_type_t.DTP_POINTER,  "mount_element",  0,  null,  "HTMLElement to mount shell into (default: document.body)"),
-SDATA(data_type_t.DTP_POINTER,  "translate",      0,  null,  "Optional i18n resolver: (key) => string. Applied to item.name / toolbar labels."),
 
 SDATA(data_type_t.DTP_POINTER,  "$container",     0,  null,  "Root HTMLElement of the shell"),
 SDATA(data_type_t.DTP_POINTER,  "priv",           0,  null,  "Private runtime state (zones/layers/stages/navs)"),
@@ -530,8 +525,7 @@ function instantiate_nav_in_zone(gobj, menu, menu_id, zone_id, level, nav_label)
             icon_pos:    render_cfg.icon_pos || default_icon_pos(zone_id),
             show_label:  render_cfg.show_label !== false,
             level:       level,
-            shell:       gobj,
-            translate:   gobj_read_attr(gobj, "translate")
+            shell:       gobj
         },
         gobj
     );
@@ -759,8 +753,11 @@ function build_toolbar(gobj, config)
         return;
     }
 
-    let translate = gobj_read_attr(gobj, "translate") || (s => s);
-
+    /*  Toolbar labels follow the same i18n contract as nav labels:
+     *  every translatable text node carries `i18n: <canonical key>`,
+     *  which createElement2 maps to `data-i18n` on the rendered
+     *  element.  Apps swap languages by calling
+     *  refresh_language(shell.$container, t) — no DOM rebuild here. */
     let $bar = createElement2(
         ["nav", {class: "yui-toolbar navbar",
                  role: "navigation",
@@ -782,14 +779,15 @@ function build_toolbar(gobj, config)
                 ["i", {class: it.icon, "aria-hidden": "true"}]]);
         }
         if(!empty_string(it.name)) {
-            children.push(["span", {}, translate(it.name)]);
+            children.push(["span", {i18n: it.name}, it.name]);
         }
 
+        let aria_key = it.aria_label || it.name || it.id || "";
         let $item = createElement2(
             ["button", {class: "navbar-item yui-toolbar-item is-unselectable",
                         type: "button",
                         "data-toolbar-item-id": it.id || "",
-                        "aria-label": translate(it.aria_label || it.name || it.id || "")},
+                        "aria-label": aria_key},
              children]
         );
         $item.addEventListener("click", ev => {
@@ -800,32 +798,6 @@ function build_toolbar(gobj, config)
     }
 
     $zone.appendChild($bar);
-}
-
-/************************************************************
- *  Rebuild the toolbar in place: removes the existing one
- *  from its zone (if any) and re-runs build_toolbar with the
- *  current config.  Called by yui_shell_set_translate so the
- *  toolbar labels pick up the new resolver.
- ************************************************************/
-function rebuild_toolbar(gobj)
-{
-    let priv = gobj_read_attr(gobj, "priv");
-    if(!priv) {
-        return;
-    }
-    for(let zone_id in priv.zones) {
-        let $zone = priv.zones[zone_id];
-        if(!$zone) {
-            continue;
-        }
-        let $old = $zone.querySelector(":scope > .yui-toolbar");
-        if($old) {
-            $old.parentNode.removeChild($old);
-        }
-    }
-    let config = gobj_read_attr(gobj, "config") || {};
-    build_toolbar(gobj, config);
 }
 
 function find_toolbar_zone(config)
@@ -1255,44 +1227,18 @@ function yui_shell_open_drawer(shell_gobj, menu_id)    { open_drawer(shell_gobj,
 function yui_shell_close_drawer(shell_gobj, menu_id)   { close_drawer(shell_gobj, menu_id);  }
 function yui_shell_toggle_drawer(shell_gobj, menu_id)  { toggle_drawer(shell_gobj, menu_id); }
 
-/*  Hot-swap the i18n resolver.  Updates the `translate` attr on the
- *  shell, propagates it to every nav, rebuilds nav DOMs and the
- *  toolbar, and re-publishes EV_ROUTE_CHANGED so navs re-mark the
- *  active item under the new labels. */
-function yui_shell_set_translate(shell_gobj, fn)
-{
-    gobj_write_attr(shell_gobj, "translate", fn);
-    let priv = gobj_read_attr(shell_gobj, "priv");
-    if(!priv) {
-        return;
-    }
-    for(let nav of priv.navs) {
-        gobj_write_attr(nav, "translate", fn);
-        try {
-            yui_nav_rebuild(nav);
-        } catch(e) {
-            log_error(`C_YUI_SHELL: yui_nav_rebuild failed: ${e}`);
-        }
-    }
-    rebuild_toolbar(shell_gobj);
-
-    let current = gobj_read_attr(shell_gobj, "current_route");
-    if(!empty_string(current) && priv.item_index[current]) {
-        let entry = priv.item_index[current];
-        gobj_publish_event(shell_gobj, "EV_ROUTE_CHANGED", {
-            route: current,
-            item: entry.item,
-            parent_item: entry.parent_item,
-            stage: entry.stage || "main"
-        });
-    }
-}
+/*  Note: there is no shell-level language switch helper.  Every
+ *  translatable text node rendered by the shell and its navs is
+ *  tagged with `data-i18n` (the canonical English key).  Apps swap
+ *  language by calling
+ *      refresh_language(shell_$container, t)
+ *  from `@yuneta/gobj-js`, exactly like `c_yui_main.js` does in
+ *  `change_language()`.  The shell does not own that flow. */
 
 export {
     register_c_yui_shell,
     yui_shell_navigate,
     yui_shell_open_drawer,
     yui_shell_close_drawer,
-    yui_shell_toggle_drawer,
-    yui_shell_set_translate
+    yui_shell_toggle_drawer
 };

--- a/kernel/js/lib-yui/test-app/README.md
+++ b/kernel/js/lib-yui/test-app/README.md
@@ -46,12 +46,15 @@ Between both presets every one of the six supported layouts runs at least once.
   navigates, `help` navigates and sits on the right (`align: "end"`).
 - **Live i18n**: the `ES/EN` button on the right of the toolbar fires
   `EV_TOGGLE_LANGUAGE` (a custom user event); a tiny side controller
-  (`C_TEST_LANG`) listens for it and calls `yui_shell_set_translate`
-  with one of two trivial dictionaries. Click it and watch every menu
-  label, the secondary-nav heading, and every toolbar `<button>` label
-  swap to Spanish, then back to English. The active item highlight
-  is preserved across the swap because the shell re-publishes
-  `EV_ROUTE_CHANGED`.
+  (`C_TEST_LANG`) listens for it, flips between two trivial
+  dictionaries and calls `refresh_language(shell.$container, t)` from
+  `@yuneta/gobj-js`. Same flow `c_yui_main.js` uses in its
+  `change_language()`. The shell renders every translatable label
+  with `data-i18n="<canonical key>"` (via `createElement2`'s `i18n`
+  attribute), so a single DOM walk swaps every menu label, the
+  secondary-nav heading and every toolbar `<button>` label without
+  rebuilding any DOM. The active item highlight is preserved
+  trivially because nothing is re-rendered.
 
 ## What to look at (accordion preset)
 
@@ -63,18 +66,6 @@ Open `?preset=accordion`:
   `aria-expanded` / `aria-controls` update accordingly.
 - Keyboard: `Tab` walks the items, `Enter` / `Space` activates them, and
   `:focus-visible` outlines the active control.
-
-## Caveat — `yui_shell_set_translate` and the active highlight
-
-`yui_shell_set_translate` re-publishes `EV_ROUTE_CHANGED` so navs
-re-mark the active item under the new labels. That re-publish is
-gated on `current_route` being non-empty: if you click the ES/EN
-button **before** the first navigation has succeeded (e.g. the hash
-is empty and there is no `default_route`), the navs are rebuilt
-correctly but no highlight appears until you navigate. Production
-configs always have a `default_route`, so this is only visible in
-custom edge cases — surfaced here so it does not surprise
-integrators.
 
 ## Accessibility spot-checks
 
@@ -89,15 +80,15 @@ integrators.
 
 ## Files
 
-- `src/main.js` — registers gclasses, chooses a preset, boots the shell
-  with an identity `translate` hook.
+- `src/main.js` — registers gclasses, chooses a preset, boots the
+  shell.
 - `src/app_config.json` — default preset (vertical · icon-bar · tabs ·
   submenu · drawer + toolbar + eager lifecycle).
-- `src/app_config_accordion.json` — alternate preset (accordion + submenu
-  + drawer).
-- `src/c_test_view.js` — minimal view gobj exposing `$container`; used
-  as the `target.gclass` for every menu item.
+- `src/app_config_accordion.json` — alternate preset (accordion +
+  submenu + drawer).
+- `src/c_test_view.js` — minimal view gobj exposing `$container`;
+  used as the `target.gclass` for every menu item.
 - `src/c_test_lang.js` — small CHILD gobj that subscribes to the
-  shell's `EV_TOGGLE_LANGUAGE` and applies a dictionary via
-  `yui_shell_set_translate`. Canonical pattern for any app that needs
-  to react to custom toolbar events.
+  shell's `EV_TOGGLE_LANGUAGE` and calls `refresh_language` with a
+  Spanish or English dictionary. Canonical pattern for any app that
+  needs to react to custom toolbar events.

--- a/kernel/js/lib-yui/test-app/src/c_test_lang.js
+++ b/kernel/js/lib-yui/test-app/src/c_test_lang.js
@@ -4,12 +4,15 @@
  *      C_TEST_LANG — Language toggle controller for the test app.
  *      Subscribes to the shell's `EV_TOGGLE_LANGUAGE` (published by the
  *      toolbar item with `action.type:"event"`), flips between two
- *      trivial dictionaries on each click, and applies the new
- *      resolver via `yui_shell_set_translate`.
+ *      trivial dictionaries on each click and refreshes the DOM via
+ *      the canonical `refresh_language(element, t)` helper from
+ *      `@yuneta/gobj-js`.
  *
- *      This is the canonical pattern for any app that needs to react
- *      to custom toolbar events: a small CHILD gobj that declares the
- *      event in its FSM and subscribes to the shell.
+ *      This is the same pattern `c_yui_main.js` uses in its
+ *      `change_language()` function: every translatable text node is
+ *      tagged at render time with `data-i18n="<canonical key>"` and a
+ *      single DOM walk replaces every text node by `t(key)`.  No DOM
+ *      rebuild, no shell-specific helper.
  *
  *          Copyright (c) 2026, ArtGins.
  *          All Rights Reserved.
@@ -20,11 +23,8 @@ import {
     gobj_parent,
     gobj_read_attr, gobj_read_pointer_attr, gobj_write_attr,
     gobj_subscribe_event,
+    refresh_language,
 } from "@yuneta/gobj-js";
-
-import {
-    yui_shell_set_translate,
-} from "@yuneta/lib-yui";
 
 
 /***************************************************************
@@ -33,11 +33,10 @@ import {
 const GCLASS_NAME = "C_TEST_LANG";
 
 /*  Two minimal dictionaries — keys are the canonical English label
- *  strings the test-app uses in its app_config*.json.
- *
- *  Real apps would resolve via i18next / similar; here we keep it
- *  inline so the harness has no extra dependency. */
-const DICT_EN = {};   /*  Identity for English. */
+ *  strings the test app uses in its app_config*.json.  English is
+ *  the identity dictionary; anything not in the Spanish map falls
+ *  through to the canonical key. */
+const DICT_EN = {};
 const DICT_ES = {
     "Dashboard":         "Panel",
     "Overview":          "Resumen",
@@ -68,7 +67,7 @@ const DICT_ES = {
 const attrs_table = [
 SDATA(data_type_t.DTP_POINTER,  "subscriber",  0,  null,  "Subscriber of output events"),
 
-SDATA(data_type_t.DTP_POINTER,  "shell",       0,  null,  "C_YUI_SHELL gobj to drive translate on"),
+SDATA(data_type_t.DTP_POINTER,  "shell",       0,  null,  "C_YUI_SHELL gobj whose DOM we refresh"),
 SDATA(data_type_t.DTP_BOOLEAN,  "is_es",       0,  false, "Current language flag (true = ES, false = EN)"),
 SDATA_END()
 ];
@@ -148,8 +147,8 @@ function mt_destroy(gobj)
 
 /***************************************************************
  *  Build a translate function backed by `dict`: returns the
- *  mapped value when present, falls back to the input key
- *  (so untranslated labels still display).
+ *  mapped value when present, falls back to the input key (so
+ *  untranslated labels still display).
  ***************************************************************/
 function make_translator(dict)
 {
@@ -176,8 +175,9 @@ function make_translator(dict)
 
 /***************************************************************
  *  Toolbar fired EV_TOGGLE_LANGUAGE — flip the language flag and
- *  hot-swap the shell's translate hook.  The shell takes care of
- *  rebuilding every nav and the toolbar.
+ *  walk the shell's `$container` calling refresh_language with
+ *  the matching dictionary.  Same flow `c_yui_main.js` uses for
+ *  its language switch.
  ***************************************************************/
 function ac_toggle_language(gobj, event, kw, src)
 {
@@ -188,7 +188,9 @@ function ac_toggle_language(gobj, event, kw, src)
     let is_es = !gobj_read_attr(gobj, "is_es");
     gobj_write_attr(gobj, "is_es", is_es);
     let dict = is_es ? DICT_ES : DICT_EN;
-    yui_shell_set_translate(shell, make_translator(dict));
+    let t = make_translator(dict);
+    let $container = gobj_read_attr(shell, "$container") || document;
+    refresh_language($container, t);
     return 0;
 }
 

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -90,7 +90,7 @@ function main()
     /*  Side controller: subscribes to the shell's EV_TOGGLE_LANGUAGE
      *  (published by the toolbar's lang button) and walks the shell's
      *  $container with refresh_language() on each click. */
-    gobj_create_pure_child(
+    let test_lang = gobj_create_pure_child(
         "test_lang",
         "C_TEST_LANG",
         { shell: shell },
@@ -99,6 +99,13 @@ function main()
 
     gobj_start(yuno);
     gobj_play(yuno);
+
+    /*  c_yuno.mt_play only starts the default_service (the shell);
+     *  pure children of the yuno (like test_lang) are NOT started
+     *  automatically.  Start it explicitly so its mt_start runs and
+     *  the EV_TOGGLE_LANGUAGE subscription is registered before the
+     *  user can click the toolbar button. */
+    gobj_start(test_lang);
 }
 
 window.addEventListener("load", () => {

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -21,7 +21,6 @@ import {
     gobj_create_yuno,
     gobj_create_default_service,
     gobj_create_pure_child,
-    gobj_find_service,
     gobj_start, gobj_play,
     register_c_yuno,
     register_c_timer,
@@ -74,7 +73,11 @@ function main()
         { yuno_name: "shell test", yuno_role: "shell_test_gui", yuno_version: "0.1.0" }
     );
 
-    gobj_create_default_service(
+    /*  Capture the shell directly — gobj_create_default_service
+     *  registers __default_service__ but does NOT populate the
+     *  __jn_services__ map, so gobj_find_service("shell") would
+     *  return null.  Use the return value instead. */
+    let shell = gobj_create_default_service(
         "shell",
         "C_YUI_SHELL",
         {
@@ -87,7 +90,6 @@ function main()
     /*  Side controller: subscribes to the shell's EV_TOGGLE_LANGUAGE
      *  (published by the toolbar's lang button) and walks the shell's
      *  $container with refresh_language() on each click. */
-    let shell = gobj_find_service("shell", false);
     gobj_create_pure_child(
         "test_lang",
         "C_TEST_LANG",

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -42,15 +42,6 @@ import app_config          from "./app_config.json";
 import app_config_accordion from "./app_config_accordion.json";
 
 
-/*  Identity i18n resolver — shows the SHELL translate hook without
- *  doing any actual translation. The C_TEST_LANG controller swaps
- *  this for a Spanish dictionary on every click of the toolbar's
- *  ES/EN button (see c_test_lang.js). */
-function identity_translate(key) {
-    return key;
-}
-
-
 function pick_config()
 {
     let q = new URLSearchParams(window.location.search);
@@ -87,16 +78,15 @@ function main()
         "shell",
         "C_YUI_SHELL",
         {
-            config:    pick_config(),
-            use_hash:  true,
-            translate: identity_translate
+            config:   pick_config(),
+            use_hash: true
         },
         yuno
     );
 
     /*  Side controller: subscribes to the shell's EV_TOGGLE_LANGUAGE
-     *  (published by the toolbar's lang button) and swaps the shell's
-     *  translate hook on each click. */
+     *  (published by the toolbar's lang button) and walks the shell's
+     *  $container with refresh_language() on each click. */
     let shell = gobj_find_service("shell", false);
     gobj_create_pure_child(
         "test_lang",


### PR DESCRIPTION
## Summary

Replace the bespoke translate / set_translate / nav_rebuild machinery from PR #103 with the canonical Yuneta i18n flow already used by \`c_yui_main.js\`:

1. Every translatable text node rendered by the shell + navs is tagged with \`data-i18n=\"<canonical English key>\"\` (via \`createElement2\`'s \`i18n\` attribute).
2. To switch language, apps call \`refresh_language(shell.\$container, t)\` from \`@yuneta/gobj-js\`. No DOM rebuild, no shell-specific helper.

This also fixes the two bugs that surfaced while testing the previous version: (a) \`gobj_find_service\` returning null for default services, (b) pure children of the yuno not being started by \`c_yuno.mt_play\`.

## Public API change

- **Removed**: \`yui_shell_set_translate\`, \`yui_nav_rebuild\`, plus the \`translate\` SDATA attr on \`C_YUI_SHELL\` and \`C_YUI_NAV\`.
- **Unchanged**: every other public helper and event.
- Net diff: **−97 lines** (the rebuild machinery is gone).

The retired symbols only shipped in \`#103\` (still on the unreleased \`7.4.0\`). \`TODO #2\` (the version bump + CHANGELOG entry) has been updated to reflect the new public surface.

## Commits

- \`218fd27b8\` — refactor(lib-yui): canonical i18n via data-i18n + refresh_language
- \`907498299\` — fix(lib-yui/test-app): capture shell from \`gobj_create_default_service\` (was relying on \`gobj_find_service\` which returns null for default services)
- \`da070c1aa\` — fix(lib-yui/test-app): start \`test_lang\` explicitly so its \`mt_start\` runs (\`c_yuno.mt_play\` only starts the default_service, not pure children of the yuno)

## Test plan

- [ ] \`cd kernel/js/lib-yui && npm test\` — 13/13 \`shell_show_on\` parser tests pass.
- [ ] \`cd kernel/js/lib-yui/test-app && npm run dev\` — boots clean, no \"Publish event WITHOUT subscribers\" warning.
- [ ] On the default preset, click the **ES/EN** button on the right of the toolbar:
    - [ ] Every menu label, the secondary-nav heading, every toolbar button label swap to Spanish; click again returns to English.
    - [ ] Active item highlight is preserved across the swap.
- [ ] On \`?preset=accordion\`, the same swap works.

## Notes

- Existing GUIs (\`C_YUI_MAIN\` based) are untouched — the legacy stack continues to use its own \`change_language()\` flow.
- The \`gcflag_no_check_output_events\` flag on the shell stays — it lets apps publish arbitrary user-defined toolbar events without extending the shell's \`event_types\` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)