### PR TITLE
lib-yui shell — Escape stack, modal API, multi-menu, validator, e2e (×3 browsers)

### DIFF
--- a/.github/workflows/lib-yui.yml
+++ b/.github/workflows/lib-yui.yml
@@ -1,0 +1,59 @@
+name: lib-yui
+
+on:
+  pull_request:
+    paths:
+      - "kernel/js/lib-yui/**"
+      - "kernel/js/gobj-js/**"
+      - ".github/workflows/lib-yui.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "kernel/js/lib-yui/**"
+      - "kernel/js/gobj-js/**"
+      - ".github/workflows/lib-yui.yml"
+
+jobs:
+  unit:
+    name: unit (shell_show_on parser)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: kernel/js/lib-yui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # The repo does not track package-lock.json so `npm ci` would fail.
+      - run: npm install
+      - run: npm test
+
+  e2e:
+    name: e2e (Playwright — chromium + firefox)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: kernel/js/lib-yui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install lib-yui deps
+        run: npm install
+      - name: Install test-app deps
+        working-directory: kernel/js/lib-yui/test-app
+        run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
+      - name: Run e2e
+        run: npm run test:e2e
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: kernel/js/lib-yui/playwright-report/
+          retention-days: 7

--- a/.github/workflows/lib-yui.yml
+++ b/.github/workflows/lib-yui.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm test
 
   e2e:
-    name: e2e (Playwright — chromium + firefox)
+    name: e2e (Playwright — chromium + firefox + webkit)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -47,7 +47,7 @@ jobs:
         working-directory: kernel/js/lib-yui/test-app
         run: npm install
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+        run: npx playwright install --with-deps chromium firefox webkit
       - name: Run e2e
         run: npm run test:e2e
       - name: Upload Playwright report on failure

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,8 @@ docs/doc.yuneta.io/.myst/
 *.xcodeproj
 *.xcworkspace
 yunos/c/mqtt_broker/tests/mqtt-cli.jar
+
+# Playwright (any sub-tree)
+test-results/
+playwright-report/
+playwright/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,98 @@
 # **Changelog**
 
+## Unreleased
+    - **feat(lib-yui): declarative app shell `C_YUI_SHELL` + `C_YUI_NAV`**.
+      A JSON-driven replacement for `C_YUI_MAIN` + `C_YUI_ROUTING`, shipped
+      alongside the legacy stack (no migration planned — see
+      [`SHELL.md` §10](kernel/js/lib-yui/SHELL.md)).  New GUIs can adopt
+      the new shell; existing GUIs keep using the old one unchanged.
+      - **Layered grid**: 6 z-stacked layers (`base`, `overlay`, `popup`,
+        `modal`, `notification`, `loading`) and 7 zones (`top`, `top-sub`,
+        `left`, `center`, `right`, `bottom-sub`, `bottom`) inside `base`,
+        all driven by a single declarative JSON config.
+      - **Six menu layouts**: `vertical`, `icon-bar`, `tabs`, `drawer`,
+        `submenu`, `accordion`.  Same menu may render differently per
+        zone via `render[zone]`.  Auto-expand of the active branch on
+        accordion when the route changes.
+      - **`show_on` parser**: zone visibility per Bulma breakpoint with
+        the operators `>=`, `<=`, `<`, `>`, enumeration and `|`.  Pure
+        module (`shell_show_on.js`), 13 `node --test` unit tests.
+      - **Three lifecycle modes per item** (`eager` / `keep_alive` /
+        `lazy_destroy`) decide when the routed view is created and
+        destroyed.
+      - **Single router**: `C_YUI_NAV` publishes `EV_NAV_CLICKED`; the
+        shell publishes `EV_ROUTE_REQUESTED` (intent, audit witness)
+        and `EV_ROUTE_CHANGED` (fact).  Hash-based 2-level routing,
+        no dependency on `C_YUI_ROUTING`.
+      - **Drawer overlay** on the `overlay` layer with focus-trap
+        (Tab/Shift+Tab cycling, focus restoration on close), backdrop
+        click closes via `EV_DRAWER_CLOSE_REQUESTED` (canonical close
+        path with focus-trap release + escape-stack pop).
+      - **Escape priority chain**: `priv.escape_stack` is a LIFO of
+        `{layer, handler}`; the global `keydown` listener calls only
+        the top entry.  Modal-over-drawer closes the modal first.
+        Public API `yui_shell_push_escape` / `yui_shell_pop_escape`
+        for app-level overlays.
+      - **Modal / notification API** on top of the shell layers
+        (`yui_shell_show_info` / `show_warning` / `show_error` /
+        `show_modal` for non-blocking; `yui_shell_confirm_ok` /
+        `confirm_yesno` / `confirm_yesnocancel` for blocking dialogs
+        that resolve a Promise).  Each modal/dialog auto-pushes onto
+        the Escape stack and installs a focus-trap.  Bulma `.modal-card`
+        / `.notification` markup verbatim.  Generic focus-trap moved
+        to `shell_focus_trap.js` with 10 unit tests.
+      - **Canonical i18n via `data-i18n` + `refresh_language`**: every
+        translatable text node carries `data-i18n="<canonical key>"`;
+        apps switch language by calling
+        `refresh_language(shell.$container, t)` from `@yuneta/gobj-js`,
+        the same flow `c_yui_main.js` uses in `change_language()`.
+        Modals/dialogs accept `opts.t` so they render in the active
+        language at open time AND retranslate live afterwards.
+      - **Generalised secondary-nav loop**: `instantiate_menus()` walks
+        every menu mounted via a `"menu.<id>"` host whose items declare
+        a `submenu` (not just `menu.primary`).  Synthesised menu_id is
+        `secondary.<owning_menu_id>.<item.id>`, scoped so two
+        primary-style menus can share item ids without colliding.
+      - **`gcflag_no_check_output_events`** on the shell so the toolbar
+        can publish arbitrary user-defined events
+        (`action.type:"event"`) without each app having to extend the
+        shell's `event_types` table.
+      - **Hard contracts**: every view gclass MUST expose `$container`
+        in `mt_create`; every navigation through an empty/unknown route
+        logs `log_error` and surfaces a placeholder banner; every
+        try/catch logs via `log_warning` (no silent swallow).
+      - **`validate_config()`**: system-boundary guard run at the top
+        of `mt_start`.  Rejects malformed configs with a visible
+        "invalid config" banner instead of producing a half-built
+        shell.  Checks: object/array shapes, zone-id membership in the
+        7 valid zones, `host` syntax (`toolbar` | `menu.<id>` |
+        `stage.<id>`), stage zones declared in `shell.zones`, and
+        cross-menu route-target uniqueness (warn when two menus claim
+        the same target).
+      - **Playwright e2e harness**: 22 spec files × 2 browsers
+        (chromium + firefox) covering boot / navigation / drawer /
+        modals / multimenu / validator / lifecycle / breakpoint /
+        live-i18n.  CI workflow `.github/workflows/lib-yui.yml` runs
+        unit + e2e on PRs and pushes touching `kernel/js/lib-yui/**`
+        or `kernel/js/gobj-js/**`.
+      - **Test-app**: standalone harness in `kernel/js/lib-yui/test-app/`
+        with three presets (`default`, `?preset=accordion`,
+        `?preset=multimenu`) plus a deliberately-broken `?preset=invalid`
+        used by the validator regression test.  `C_TEST_LANG`
+        controller demonstrates the canonical pattern for reacting to
+        custom toolbar events (language toggle, hello toast, ask
+        dialog).
+      - **Docs**: [`SHELL.md`](kernel/js/lib-yui/SHELL.md) (design,
+        configuration JSON, GClasses + events, modal/notification API,
+        Escape chain, internationalisation),
+        [`TODO.md`](kernel/js/lib-yui/TODO.md) (status of every task on
+        the new shell), updated `lib-yui/README.md` with the
+        "Which app shell to use?" decision tree.
+      - **CLAUDE.md**: new "GClass section layout" addendum (JS skeleton
+        banners + canonical CHILD/SERVICE subscription model + Always
+        braces rule + EVF_NO_WARN_SUBS) so future agents stay on the
+        rails the user established for this work.
+
 ## v7.3.0 -- 18/Apr/2026
     - **feat(ytls, c_yuno, c_agent): TLS certificate hot-reload with
       three-layer defence-in-depth**. Lets a Yuneta host keep thousands of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,15 @@
         `stage.<id>`), stage zones declared in `shell.zones`, and
         cross-menu route-target uniqueness (warn when two menus claim
         the same target).
-      - **Playwright e2e harness**: 22 spec files × 2 browsers
-        (chromium + firefox) covering boot / navigation / drawer /
-        modals / multimenu / validator / lifecycle / breakpoint /
-        live-i18n.  CI workflow `.github/workflows/lib-yui.yml` runs
-        unit + e2e on PRs and pushes touching `kernel/js/lib-yui/**`
-        or `kernel/js/gobj-js/**`.
+      - **Playwright e2e harness**: 22 spec files × 3 browsers
+        (chromium + firefox + webkit) = 69 tests covering boot /
+        navigation / drawer / modals / multimenu / validator /
+        lifecycle / breakpoint / live-i18n.  CI workflow
+        `.github/workflows/lib-yui.yml` runs unit + e2e on PRs and
+        pushes touching `kernel/js/lib-yui/**` or
+        `kernel/js/gobj-js/**`.  `kernel/js/lib-yui/install-e2e-deps.sh`
+        helper installs the apt packages WebKit links against
+        (`libgstreamer-plugins-bad1.0-0`, `libavif16`).
       - **Test-app**: standalone harness in `kernel/js/lib-yui/test-app/`
         with three presets (`default`, `?preset=accordion`,
         `?preset=multimenu`) plus a deliberately-broken `?preset=invalid`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,28 @@ npm run test:watch     # vitest --watch
 npm run test:coverage  # vitest --coverage
 ```
 
+### lib-yui (kernel/js/lib-yui/)
+
+```bash
+cd kernel/js/lib-yui
+npm install
+npm test               # node --test (parser + focus-trap unit tests)
+
+# Optional: end-to-end Playwright suite (chromium + firefox + webkit)
+./install-e2e-deps.sh  # one-off: downloads browsers + sudo apts for webkit
+npm run test:e2e       # headless full matrix
+npm run test:e2e:ui    # Playwright UI mode (debug)
+```
+
+The `install-e2e-deps.sh` helper is a thin wrapper around
+`npx playwright install` plus the `sudo apt` packages WebKit links
+against (`libgstreamer-plugins-bad1.0-0`, `libavif16` on
+Debian/Ubuntu).  Chromium and Firefox bundle their own deps and
+don't need apt.
+
+CI runs the same matrix on every PR touching `kernel/js/lib-yui/**`
+or `kernel/js/gobj-js/**` via `.github/workflows/lib-yui.yml`.
+
 ### When to re-run `yunetas init`
 
 `yunetas init` must be run:

--- a/docs/doc.yuneta.io/index.md
+++ b/docs/doc.yuneta.io/index.md
@@ -12,7 +12,7 @@ title: Yuneta Simplified
 
 **Current version: [7.3.0](https://github.com/artgins/yunetas/tree/7.3.0)**
 
-*Documentation updated: 2026-04-18*
+*Documentation updated: 2026-04-27*
 :::
 
 :::{grid-item}

--- a/docs/doc.yuneta.io/installation.md
+++ b/docs/doc.yuneta.io/installation.md
@@ -73,6 +73,21 @@ pipx install kconfiglib
 - `telnet`                  — required by tests
 ```
 
+### Optional: lib-yui end-to-end tests (Playwright)
+
+If you intend to run the JS UI library's e2e suite locally, the
+WebKit browser links against two extra apt packages on Debian/Ubuntu:
+
+```bash
+sudo apt -y install --no-install-recommends \
+    libgstreamer-plugins-bad1.0-0 libavif16
+```
+
+The `kernel/js/lib-yui/install-e2e-deps.sh` helper installs them
+along with all three Playwright browsers (Chromium, Firefox,
+WebKit).  Chromium and Firefox bundle their own deps and don't
+need anything from apt.
+
 ## Install `yunetas`
 
 ::::{tab-set}

--- a/kernel/js/lib-yui/.gitignore
+++ b/kernel/js/lib-yui/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -325,6 +325,51 @@ Public helpers (import from `@yuneta/lib-yui`):
   close the focus is restored to whichever element triggered the
   open.
 
+### Modal / notification API
+
+The shell paints into `priv.layers.notification` and
+`priv.layers.modal`. Two naming conventions:
+
+- `yui_shell_show_*` — non-blocking notifications/modal. Returns a
+  `{ close() }` handle so the caller can dismiss programmatically.
+- `yui_shell_confirm_*` — blocking dialog. Returns a Promise that
+  resolves with the user's choice.
+
+```js
+import {
+    yui_shell_show_info, yui_shell_show_warning, yui_shell_show_error,
+    yui_shell_show_modal,
+    yui_shell_confirm_ok, yui_shell_confirm_yesno, yui_shell_confirm_yesnocancel,
+} from "@yuneta/lib-yui";
+
+/*  Toasts (Bulma .notification, auto-dismiss after 5 s). */
+yui_shell_show_info(shell,    "Hello");
+yui_shell_show_warning(shell, "Watch out");
+yui_shell_show_error(shell,   "Boom");
+
+/*  Non-blocking modal (Bulma .modal-content + .box).  Click on
+ *  background, the close button or Escape close it. */
+let { close } = yui_shell_show_modal(shell, "Some inline content");
+
+/*  Blocking dialogs.  Escape, the close button, and click on the
+ *  background all resolve with the LAST button's value (cancel/no/
+ *  ok by convention — the safe-default action). */
+await yui_shell_confirm_ok(shell, "Saved.");
+let yes = await yui_shell_confirm_yesno(shell, "Discard changes?");
+let r   = await yui_shell_confirm_yesnocancel(shell, "Save before close?");
+//   r === "yes" | "no" | "cancel"
+```
+
+Every modal/dialog automatically:
+- pushes a close handler onto the Escape priority chain (§11),
+- installs a focus-trap on the modal card (Tab cycles inside,
+  Shift+Tab cycles backwards, focus is restored on close),
+- removes itself from the DOM when closed.
+
+The legacy `display_*` / `get_yes*` helpers in `c_yui_main.js`
+remain unchanged; see §10 *drift policy*. Apps importing one stack
+should not import the other.
+
 ### Internationalisation
 
 The shell does **not** own i18n. Every translatable text node it

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -401,12 +401,27 @@ Published events:
 - `EV_NAV_CLICKED` — `{ route, item_id, zone, level }`. The shell is
   subscribed and decides whether to change the hash or call
   `navigate_to` directly.
+- `EV_DRAWER_CLOSE_REQUESTED` — `{ menu_id }`. Published by drawer
+  navs when the backdrop is clicked; the shell's
+  `ac_drawer_close_requested` runs the canonical close path.
 
 Notable attributes: `menu_items`, `zone`, `layout`, `icon_pos`,
 `show_label`, `level` (`primary` | `secondary`), `shell`,
 `nav_label` (human-readable label used by the secondary navs as
 their heading and `aria-label`; the shell fills it from the parent
 item's `name`).
+
+### Secondary nav `menu_id`
+
+The shell auto-instantiates a level-2 nav for every primary-style
+menu item that declares a `submenu` with its own `render` block —
+not just `menu.primary`. The synthesised `menu_id` for a secondary
+nav is `secondary.<owning_menu_id>.<item.id>`, so two primary-style
+menus may have items with the same id without colliding (e.g.
+`secondary.primary.dash` and `secondary.admin.dash` are independent
+navs that flip visibility based on the active route's owning menu).
+
+### i18n
 
 The nav has no `translate` attr — it does not translate text
 itself. Labels are emitted with `data-i18n` and a single
@@ -600,14 +615,7 @@ These are intentional gaps, documented so they don't surface as
 review nits.  Each one has a clear path forward when it becomes
 worth the work.
 
-1. **Secondary navs are auto-instantiated only from `menu.primary`.**
-   `instantiate_menus` walks `menus.primary.items[*].submenu` to
-   build the level-2 navs.  If you declare additional "primary-style"
-   menus elsewhere with their own `submenu`, those submenus will
-   not get a nav unless they are mounted manually.  Drawer overlays
-   (`render[zone].layout === "drawer"`) are detected for any menu
-   id and are not subject to this limitation.
-2. **Do not import `c_yui_main.css` and `c_yui_shell.css` together.**
+1. **Do not import `c_yui_main.css` and `c_yui_shell.css` together.**
    `c_yui_main.css` defines its own `.top-layer` / `.content-layer` /
    `.bottom-layer` with `position:fixed` and CSS variables that
    collide with the shell's full-screen grid.  Pick one: the new

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -502,7 +502,54 @@ Until that decision is made, do **not** start any of those sub-tasks.
 
 ---
 
-## 11. Known limitations
+## 11. Escape priority chain
+
+The shell maintains a **single, ordered stack** of close handlers,
+one entry per open overlay (drawer today, modal/popup when #4
+lands, custom app overlays via the public API). `Escape` calls the
+**top** entry only and consumes the event (preventDefault +
+stopPropagation), so a modal opened over a drawer closes first;
+the second `Escape` closes the drawer.
+
+LIFO ordering naturally matches the z-index layering most apps
+use:
+
+```
+loading       (no Escape — full-screen blocking spinner)
+modal         (z-index 99)
+popup         (z-index 20)
+overlay       (z-index 15)  ← drawer lives here
+base          (z-index  1)  ← never on the Escape stack
+```
+
+The drawer integration is built in: `yui_shell_open_drawer` /
+`toggle_drawer` push their close handler; `yui_shell_close_drawer`,
+the backdrop click, and `Escape` itself all funnel through the
+same close path (`close_drawer_one`) which removes
+`is-active`, releases the focus-trap, and pops the stack entry.
+
+The backdrop click is routed via `EV_DRAWER_CLOSE_REQUESTED` from
+the nav to the shell, not by mutating the DOM directly — that
+guarantees the focus-trap and stack stay in sync regardless of
+which path closed the drawer.
+
+### Public API (for custom overlays)
+
+```js
+import { yui_shell_push_escape, yui_shell_pop_escape } from "@yuneta/lib-yui";
+
+let close_modal = () => my_modal.close();
+yui_shell_push_escape(shell, "modal", close_modal);
+//   ... when the modal closes by any path (Escape, overlay click,
+//   programmatic close, ...) the same handler must also pop:
+yui_shell_pop_escape(shell, close_modal);
+```
+
+`layer` is a free-form tag (e.g. `"modal"`, `"popup"`,
+`"overlay"`). It is informational today (the LIFO ordering is what
+drives priority); keep it accurate so the FSM trace is readable.
+
+## 12. Known limitations
 
 These are intentional gaps, documented so they don't surface as
 review nits.  Each one has a clear path forward when it becomes

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -298,7 +298,20 @@ Recommended default: `keep_alive`.
 | `$container`     | HTMLElement | Shell root                                               |
 
 Published events:
-- `EV_ROUTE_CHANGED` — `{ route, item, parent_item, stage }`.
+- `EV_ROUTE_REQUESTED` — `{ route, from }`. **Audit witness**:
+  published as the very first thing in `navigate_to()`, **before**
+  any validation or DOM work, so the FSM trace and any external
+  auditor see every navigation intent — including rerouted submenu
+  defaults and routes that ultimately fail. Subscribers are
+  optional (the event carries `EVF_NO_WARN_SUBS`).
+- `EV_ROUTE_CHANGED` — `{ route, item, parent_item, stage }`. The
+  fact event, published after a navigation has fully succeeded:
+  the previous view is hidden, the new view is mounted/shown, the
+  stage's `active_route` is updated.
+
+The pair *requested ↔ changed* is the canonical Yuneta way to
+audit a gobj's behaviour: every intent is recorded regardless of
+outcome, and every successful state transition has its own event.
 
 Public helpers (import from `@yuneta/lib-yui`):
 - `yui_shell_navigate(shell, route)` — programmatic navigation.

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -190,35 +190,48 @@ with submenus and both render their secondary navs correctly.
 
 ## 6. End-to-end smoke with Playwright
 
-Today there is **no automated smoke** of the shell — only the 13
-`shell_show_on` parser tests run in CI.  Add a thin Playwright
-suite.
+Today the only automated coverage is the 13 `shell_show_on`
+parser tests — Playwright wraps the actual UI.
 
-- Boot the test-app via `vite preview` against the built bundle.
-- Two presets, two browsers (chromium + firefox at minimum).
-- Tests, in order of priority:
-    1. **boot**: `/dash/ov` renders, the card title is "Overview".
-    2. **navigation**: clicking each primary item changes the
-       active highlight and the centre stage.
-    3. **breakpoint**: viewport at 800 px shows the bottom
-       icon-bar; at 1280 px shows the left vertical menu.
-    4. **drawer**: hamburger opens drawer, focus moves into the
-       panel, `Tab` cycles inside, `Escape` closes and restores
-       focus to the burger button.
-    5. **escape stack** (after #3): modal over drawer, Escape
-       closes the modal first, then the drawer.
-    6. **lifecycle**: visiting `/dash/alerts` (`lazy_destroy`)
-       twice increments the `instance #` counter; `/dash/ov`
-       (`keep_alive`) does not.
-    7. **live-translate**: clicking the ES/EN button (#1) flips
-       labels everywhere.
-- Wire `npm run test:e2e` from `kernel/js/lib-yui/`.
-- Add a CI workflow stub (`.github/workflows/lib-yui.yml`) that
-  runs `npm test` (parser) + `npm run test:e2e` on PRs touching
-  `kernel/js/lib-yui/**`.
+### Done in the first pass
+- `playwright.config.js` boots the test-app via `vite preview`
+  against the built bundle on port 5181 (chromium + firefox,
+  `webServer` auto-starts before tests).
+- `npm run test:e2e` / `npm run test:e2e:ui` / `npm run test:all`
+  wired up.
+- `.github/workflows/lib-yui.yml` runs unit + e2e on PRs and on
+  `main` touching `kernel/js/lib-yui/**` or `kernel/js/gobj-js/**`.
+  Uploads the Playwright HTML report on failure.
+- `tests-e2e/boot.spec.mjs`:
+    * default preset lands on `/dash/ov` with the Overview card,
+      the URL hash mirrors the route, the primary nav has its
+      active item, and the boot is console-error-clean.
+    * accordion preset auto-expands the Dashboard branch
+      (`aria-expanded="true"`) and lands on Overview.
+- `tests-e2e/navigation.spec.mjs`:
+    * clicks each primary item, asserts the URL hash and the
+      centre-stage card title.
+    * typed-URL hash navigation lands on the right card.
+    * back/forward replays the route history.
+    * submenu container `/dash` redirects to `/dash/ov`.
 
-**Done when:** CI green on the branch and the workflow gates the
-PR.
+### Pending — to be added as the corresponding feature lands
+- **breakpoint**: viewport at 800 px shows the bottom icon-bar;
+  at 1280 px shows the left vertical menu.
+- **drawer**: hamburger opens drawer, focus moves into the panel,
+  `Tab` cycles inside, `Escape` closes and restores focus to the
+  burger button.
+- **escape stack** (after #3): modal over drawer, Escape closes
+  the modal first, then the drawer.
+- **modal** (after #4): toolbar item triggers
+  `yui_shell_show_info`; the toast is in the notification layer.
+- **lifecycle**: visiting `/dash/alerts` (`lazy_destroy`) twice
+  increments the `instance #` counter; `/dash/ov` (`keep_alive`)
+  does not.
+- **live-translate**: clicking the ES/EN button flips labels
+  everywhere; the active highlight is preserved.
+
+**Done when:** CI green on the branch with all bullets above.
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -90,29 +90,37 @@ publish:
 
 ---
 
-## 3. Escape priority chain (modal > drawer > popup)
+## 3. Escape priority chain (modal > drawer > popup) — DONE
 
-The shell's global `keydown` listener unconditionally closes any
-open drawer on `Escape`.  Once modals (#4) and any future popup
-component land, this becomes wrong — closing the modal first,
-*then* the drawer, *then* the popup is the universal expectation.
+`priv.escape_stack` is a LIFO of `{ layer, handler }` records
+pushed by every overlay when it opens and popped when it closes.
+The window-level `keydown` listener calls only the top entry and
+consumes the event (preventDefault + stopPropagation).
 
-**Land this BEFORE #4** so modals are born already aware of the
-stack.
+- `open_drawer` / `close_drawer` / `toggle_drawer` /
+  `close_all_drawers` go through `open_drawer_one` /
+  `close_drawer_one`, which keep DOM (`is-active`), focus-trap,
+  and escape-stack in sync.
+- The backdrop click in `c_yui_nav.js` no longer mutates the DOM
+  directly; it publishes the new `EV_DRAWER_CLOSE_REQUESTED`
+  output event with `{menu_id}`. The shell's
+  `ac_drawer_close_requested` calls the canonical close path —
+  closing the focus-trap leak that was open since the drawer
+  landed.
+- Public API for non-drawer overlays (used by #4 modals and any
+  future popup): `yui_shell_push_escape(shell, layer, handler)` /
+  `yui_shell_pop_escape(shell, handler)`. Both re-exported from
+  `@yuneta/lib-yui`.
+- `SHELL.md` §11 documents the LIFO ordering, the z-index
+  rationale (loading > modal > popup > overlay), and the public
+  API.
+- `tests-e2e/drawer.spec.mjs` covers: burger opens / Escape
+  closes / focus restored; backdrop click closes via the
+  canonical path; Escape with the stack empty is a no-op.
 
-- Refactor `priv.keydown_handler` into a stack `priv.escape_stack`:
-  an array of close handlers.  Each interactive overlay pushes its
-  handler when it opens and pops it when it closes.  Escape calls
-  the **top** handler only and consumes the event.
-- Order of priority by `z-index` of the layer the overlay lives in:
-  `loading` (no Escape) > `modal` > `popup` > `overlay` (drawer).
-- Refactor `open_drawer` / `close_drawer` / `toggle_drawer` to use
-  the stack instead of calling `close_all_drawers` directly.
-- Document the order in `SHELL.md` §11 and add a regression test in
-  the e2e suite once #6 is up.
-
-**Done when:** with a modal open over a drawer, Escape closes the
-modal first; second Escape closes the drawer.
+The cross-overlay test (modal over drawer → first Escape closes
+the modal, second Escape closes the drawer) lands with #4 once
+modals exist.
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -236,8 +236,8 @@ parser tests — Playwright wraps the actual UI.
 
 ### Done in the first pass
 - `playwright.config.js` boots the test-app via `vite preview`
-  against the built bundle on port 5181 (chromium + firefox,
-  `webServer` auto-starts before tests).
+  against the built bundle on port 5181 (chromium + firefox +
+  webkit, `webServer` auto-starts before tests).
 - `npm run test:e2e` / `npm run test:e2e:ui` / `npm run test:all`
   wired up.
 - `.github/workflows/lib-yui.yml` runs unit + e2e on PRs and on
@@ -275,7 +275,18 @@ parser tests — Playwright wraps the actual UI.
   translatable label and preserves the active highlight.
 
 **Done when:** CI green on the branch with every spec above.
-22 specs × 2 browsers = 44 e2e tests, all green locally.
+22 specs × 3 browsers (chromium + firefox + webkit) = 69 e2e tests,
+all green locally on Linux after running
+`./install-e2e-deps.sh`.
+
+### Acknowledged debt (not blocking the merge)
+
+- **Focus-trap unit tests use hand-rolled DOM stubs.**  Acceptable
+  while the trap stays simple and the stubs cover every branch
+  (Tab / Shift+Tab / non-Tab key / focus-from-outside / release
+  idempotency / missing panel / empty panel).  Switch to `jsdom`
+  or `happy-dom` if a real edge case appears (Shadow DOM, `inert`,
+  native `<dialog>`, `tabindex` derived from CSS, etc.).
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -124,53 +124,70 @@ modals exist.
 
 ---
 
-## 4. Modal / notification API on top of the shell layers
+## 4. Modal / notification API on top of the shell layers — DONE
 
-Today the shell creates `priv.layers.modal`, `priv.layers.notification`
-and `priv.layers.loading` in `build_ui` but exposes no API for them.
-New GUIs built on the shell should be able to render modals and
-toasts **without** importing `c_yui_main.js`.
+Two new modules, one inline refactor, seven public helpers.
 
-The legacy entry points (`display_volatil_modal`, `display_info_message`,
-`display_warning_message`, `display_error_message`, `get_yesnocancel`,
-`get_yesno`, `get_ok`) stay in `c_yui_main.js` for legacy apps and
-are **not** removed.  The new shell exposes a parallel API instead.
+### Generic focus-trap → `src/shell_focus_trap.js`
+- `FOCUSABLE_SELECTOR` constant + `activate_focus_trap_on($panel,
+  doc?)` returning a `release()` function. Pure module, no Yuneta
+  deps. The optional `doc` arg lets unit tests inject a stub.
+- The drawer's inline focus-trap in `c_yui_shell.js` is gone;
+  `open_drawer_one` now calls `activate_focus_trap_on(panel)` and
+  parks the returned release fn on `$drawer.__yui_focus_release__`.
+  `close_drawer_one` invokes it. The `priv.drawer_focus_states` Map
+  is gone too.
+- `tests/shell_focus_trap.test.mjs`: 10 unit tests with hand-rolled
+  DOM stubs (no extra devDep). Brings the parser+focus-trap unit
+  total to 23/23.
 
-- **Generalise** the drawer focus-trap (`activate_focus_trap` /
-  `release_focus_trap` / `FOCUSABLE_SELECTOR`) into a generic
-  `activate_focus_trap_on($element)` and move it to
-  `src/shell_focus_trap.js` for unit-testability alongside
-  `shell_show_on.js`.  Add a small `tests/shell_focus_trap.test.mjs`
-  using happy-dom (or a tiny stub) so the runner gets its second
-  client.
-- Add shell-level helpers — distinct names from the legacy ones to
-  avoid ambiguity for consumers that might import both.  Naming
-  convention: `yui_shell_show_*` for non-blocking notifications
-  (no answer expected from the user), `yui_shell_confirm_*` for
-  blocking dialogs (the helper resolves with the user's choice).
-    - Non-blocking: `yui_shell_show_modal`, `yui_shell_show_info`,
-      `yui_shell_show_warning`, `yui_shell_show_error`.
-    - Blocking: `yui_shell_confirm_yesnocancel`,
-      `yui_shell_confirm_yesno`, `yui_shell_confirm_ok` (single OK
-      button — still a dialog the user has to dismiss, hence
-      `confirm_*`, not `show_*`).
-  Re-export from `index.js`.
-- Reuse Bulma's `.modal` / `.notification` markup verbatim for visual
-  parity with the legacy implementation.
-- Each modal/popup that grabs focus must register a close handler on
-  the Escape stack from #3.
-- Add a smoke entry in `test-app/app_config.json`: a toolbar item
-  that fires `yui_shell_show_info(shell, "Hello")` so the toast
-  renders without any view doing it.
+### Shell-level helpers → `src/shell_modals.js`
+Naming convention: `yui_shell_show_*` for non-blocking,
+`yui_shell_confirm_*` for blocking dialogs that resolve a Promise.
+- **Non-blocking**: `yui_shell_show_info`, `yui_shell_show_warning`,
+  `yui_shell_show_error`, `yui_shell_show_modal`. Toasts auto-
+  dismiss after `opts.timeout` ms (default 5000; `0` disables).
+  Each returns a `{ close() }` handle.
+- **Blocking**: `yui_shell_confirm_ok`, `yui_shell_confirm_yesno`,
+  `yui_shell_confirm_yesnocancel`. Each returns a Promise that
+  resolves with the user's choice (`undefined` / boolean /
+  `"yes"|"no"|"cancel"` respectively). Escape, the close button
+  and click on the background all resolve with the LAST button's
+  value (cancel/no/ok — safe-default convention).
+- Every modal/dialog automatically pushes a close handler onto the
+  Escape priority chain (§11) and installs a focus-trap on the
+  modal card. `Tab`/`Shift+Tab` cycle inside, focus is restored on
+  close.
+- All seven re-exported from `@yuneta/lib-yui`.
 
-**Drift policy** between the new helpers and the legacy `display_*`
-/ `get_yes*` / `get_ok` is documented in
-[`SHELL.md` §10](./SHELL.md): legacy bug fixes are not back-ported,
-shell improvements stay on the shell.
+### Smoke entries in the test-app
+`app_config.json` toolbar grew two items: `Hello` (fires
+`EV_SHOW_HELLO` → `yui_shell_show_info`) and `Ask` (fires
+`EV_ASK_QUESTION` → `yui_shell_confirm_yesno` + a follow-up info
+toast). The `c_test_lang` controller picked up the two new
+actions/events. No new gobj.
 
-**Done when:** new GUIs can render every modal/toast variant through
-shell helpers without importing `c_yui_main.js`; the legacy helpers
-remain untouched.
+### e2e (`tests-e2e/modals.spec.mjs`)
+Four tests × 2 browsers = 8 new e2e tests:
+- Hello toolbar item paints a `.notification` on the notification
+  layer; clicking the `.delete` button dismisses.
+- Ask toolbar item opens a yes/no dialog; clicking *Yes* resolves
+  the Promise and shows the follow-up toast.
+- Escape on an open dialog dismisses with the last button's value
+  (= the *No* answer in this case).
+- **Modal over drawer**: open the drawer, then open a modal on top
+  of it (synthetic click bypasses the drawer's pointer occlusion);
+  first Escape closes the modal, the drawer remains open; second
+  Escape closes the drawer. This is the cross-overlay test that
+  was deferred from #3.
+
+### Drift policy
+Documented in `SHELL.md §10`: legacy `display_*` / `get_yes*` /
+`get_ok` bug fixes are NOT back-ported to `yui_shell_show_*` /
+`yui_shell_confirm_*` and vice versa. The two stacks are
+parallel.
+
+Tests: parser + focus-trap 23/23, e2e 26/26 (chromium + firefox).
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -256,23 +256,26 @@ parser tests — Playwright wraps the actual UI.
     * back/forward replays the route history.
     * submenu container `/dash` redirects to `/dash/ov`.
 
-### Pending — to be added as the corresponding feature lands
-- **breakpoint**: viewport at 800 px shows the bottom icon-bar;
-  at 1280 px shows the left vertical menu.
-- **drawer**: hamburger opens drawer, focus moves into the panel,
-  `Tab` cycles inside, `Escape` closes and restores focus to the
-  burger button.
-- **escape stack** (after #3): modal over drawer, Escape closes
-  the modal first, then the drawer.
-- **modal** (after #4): toolbar item triggers
-  `yui_shell_show_info`; the toast is in the notification layer.
-- **lifecycle**: visiting `/dash/alerts` (`lazy_destroy`) twice
-  increments the `instance #` counter; `/dash/ov` (`keep_alive`)
-  does not.
-- **live-translate**: clicking the ES/EN button flips labels
-  everywhere; the active highlight is preserved.
+### Done in the second pass (this branch)
+- `tests-e2e/drawer.spec.mjs` (3) — burger+Escape+focus restore;
+  backdrop closes via canonical path; Escape with stack empty.
+- `tests-e2e/modals.spec.mjs` (4) — info toast; yes/no dialog;
+  Escape dismisses; modal-over-drawer escape order.
+- `tests-e2e/multimenu.spec.mjs` (1) — two primary-style menus,
+  cross-menu secondary scoping.
+- `tests-e2e/validator.spec.mjs` (1) — invalid preset surfaces
+  the banner and the matching console errors.
+- `tests-e2e/lifecycle.spec.mjs` (3) — keep_alive reuses
+  instance, lazy_destroy mints a new one, eager is
+  preinstantiated.
+- `tests-e2e/breakpoint.spec.mjs` (3) — desktop: left vertical
+  + no bottom; mobile: bottom icon-bar + no left; tablet:
+  toolbar appears.
+- `tests-e2e/i18n.spec.mjs` (1) — ES/EN button flips every
+  translatable label and preserves the active highlight.
 
-**Done when:** CI green on the branch with all bullets above.
+**Done when:** CI green on the branch with every spec above.
+22 specs × 2 browsers = 44 e2e tests, all green locally.
 
 ---
 

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -1,317 +1,31 @@
 # `lib-yui` shell — pending work
 
-Living TODO for the declarative shell refactor on branch
-`claude/refactor-gui-system-qptVn`.  Numbered roughly by dependency
-order; do not skip ahead without reading the rationale on each item.
+Living TODO for the declarative shell.  Everything originally on
+this list (the new shell + nav, escape stack, modal/notification
+API, generalised secondary-nav loop, validator, Playwright e2e on
+three browsers) is **done** and currently riding on PR #105.
 
-**Scope decision (2026-04):** existing GUIs will **not** be migrated
-to the new shell.  `C_YUI_MAIN` and `C_YUI_ROUTING` stay shipped and
-supported so legacy apps keep working unchanged.  The new shell
-(`C_YUI_SHELL` + `C_YUI_NAV`) targets **new** GUIs only.  The
-migration of legacy apps is captured as an optional, gated track at
-the end of this file (#8) for whoever decides to take it on later.
-
-The arc this list closes:
-
-> The original review scope (10 findings, 4 blockers) is **done**.
-> What remains is the polish needed to make the new shell a
-> first-class option for new GUIs (modals, escape stack, secondary-
-> nav generalisation, e2e smoke), plus the release cut on top of
-> which new apps can ride.  Legacy `C_YUI_MAIN` / `C_YUI_ROUTING`
-> are explicitly out of scope here.
-
-Order rationale (revised after the "no legacy migration" decision):
-
-- #1 + #2 close the original review scope and let us cut a `7.4.0`
-  release that new GUIs can adopt.
-- #3 (Escape stack) lands **before** #4 (modals) on purpose: any
-  modal/popup component will register itself on the stack, retro-
-  fitting it after the fact is much more painful.
-- #4 (Modal/notification API) makes the new shell self-sufficient
-  for new GUIs — they don't need to import `c_yui_main.js` for
-  toasts/dialogs.
-- #5 (secondary-nav generalisation) removes the `menu.primary`-only
-  limitation so new GUIs with multiple primary-style menus work.
-- #6 (Playwright e2e) gates regressions on the shell itself.
-- #7 closes the branch.
-- #8 is the **optional** legacy-migration track, kept here as a
-  reference checklist if the decision is ever revisited.
+`CHANGELOG.md` carries the full feature list under `## Unreleased`.
 
 ---
 
-## 1. Test-app: language-switch button (smoke for `refresh_language`)
+## 1. Cut the `7.4.0` release
 
-**Status: DONE** (canonical pattern).
+`kernel/js/lib-yui/package.json` is still at `7.3.0`.  Once PR #105
+merges and we want to publish to npm:
 
-The shell tags every translatable text node with
-`data-i18n="<canonical key>"` (via `createElement2`'s `i18n` attr).
-Apps switch language by calling
-`refresh_language(shell.$container, t)` from `@yuneta/gobj-js` —
-the same flow `c_yui_main.js` uses in its `change_language()`.
-There is no shell-level translate hook and no DOM rebuild.
+- Bump `kernel/js/lib-yui/package.json` to `7.4.0`.
+- Move the `## Unreleased` block in the top-level `CHANGELOG.md` to
+  `## v7.4.0 -- <date>`.
+- `npm publish --access public` from `kernel/js/lib-yui/` (the
+  `prepublishOnly` script runs `vite build` automatically).
 
-The test-app exercises this with:
-- A `lang` toolbar item (`align: "end"`) that fires the user-defined
-  `EV_TOGGLE_LANGUAGE` via `action.type:"event"`.  The shell is
-  registered with `gcflag_no_check_output_events` so it forwards the
-  event without the app having to extend its `event_types` table.
-- A small CHILD gobj `C_TEST_LANG` that subscribes to that event and
-  calls `refresh_language(shell.$container, t)` with one of two
-  trivial dictionaries (EN identity / ES map).
+**Done when:** `@yuneta/lib-yui@7.4.0` is on npmjs.com and the
+CHANGELOG has the dated section instead of `## Unreleased`.
 
 ---
 
-## 2. Bump `lib-yui` to `7.4.0` + top-level CHANGELOG entry
-
-`kernel/js/lib-yui/package.json` is still on `7.3.0`.  Before any
-publish:
-
-- Bump to `7.4.0`.
-- Add a section to top-level `CHANGELOG.md`:
-    - **Added**: `C_YUI_SHELL`, `C_YUI_NAV`, `shell_show_on` parser
-      with 13 `node --test` tests, declarative toolbar, all 6 nav
-      layouts, drawer overlay with focus-trap, canonical i18n
-      (every translatable label rendered with
-      `data-i18n="<canonical key>"`; apps switch language by calling
-      `refresh_language(shell.$container, t)` from
-      `@yuneta/gobj-js`), public helpers
-      `yui_shell_navigate / yui_shell_open_drawer /
-      yui_shell_close_drawer / yui_shell_toggle_drawer`.
-    - **Fixed (review pass)**: `build_item_index` route collision,
-      drawer staying open after navigation, vite alias matching
-      sub-paths, missing drawer helper re-exports, ugly
-      `secondary.<id>` heading via the new `nav_label` attribute.
-    - **Note**: `C_YUI_MAIN` and `C_YUI_ROUTING` remain shipped and
-      fully supported.  The new shell is the recommended path for
-      **new** GUIs only; legacy GUIs keep using the old classes.
-      Optional migration tasks tracked in `TODO.md` §8.
-
-**Done when:** version bumped, CHANGELOG entry merged.
-
----
-
-## 3. Escape priority chain (modal > drawer > popup) — DONE
-
-`priv.escape_stack` is a LIFO of `{ layer, handler }` records
-pushed by every overlay when it opens and popped when it closes.
-The window-level `keydown` listener calls only the top entry and
-consumes the event (preventDefault + stopPropagation).
-
-- `open_drawer` / `close_drawer` / `toggle_drawer` /
-  `close_all_drawers` go through `open_drawer_one` /
-  `close_drawer_one`, which keep DOM (`is-active`), focus-trap,
-  and escape-stack in sync.
-- The backdrop click in `c_yui_nav.js` no longer mutates the DOM
-  directly; it publishes the new `EV_DRAWER_CLOSE_REQUESTED`
-  output event with `{menu_id}`. The shell's
-  `ac_drawer_close_requested` calls the canonical close path —
-  closing the focus-trap leak that was open since the drawer
-  landed.
-- Public API for non-drawer overlays (used by #4 modals and any
-  future popup): `yui_shell_push_escape(shell, layer, handler)` /
-  `yui_shell_pop_escape(shell, handler)`. Both re-exported from
-  `@yuneta/lib-yui`.
-- `SHELL.md` §11 documents the LIFO ordering, the z-index
-  rationale (loading > modal > popup > overlay), and the public
-  API.
-- `tests-e2e/drawer.spec.mjs` covers: burger opens / Escape
-  closes / focus restored; backdrop click closes via the
-  canonical path; Escape with the stack empty is a no-op.
-
-The cross-overlay test (modal over drawer → first Escape closes
-the modal, second Escape closes the drawer) lands with #4 once
-modals exist.
-
----
-
-## 4. Modal / notification API on top of the shell layers — DONE
-
-Two new modules, one inline refactor, seven public helpers.
-
-### Generic focus-trap → `src/shell_focus_trap.js`
-- `FOCUSABLE_SELECTOR` constant + `activate_focus_trap_on($panel,
-  doc?)` returning a `release()` function. Pure module, no Yuneta
-  deps. The optional `doc` arg lets unit tests inject a stub.
-- The drawer's inline focus-trap in `c_yui_shell.js` is gone;
-  `open_drawer_one` now calls `activate_focus_trap_on(panel)` and
-  parks the returned release fn on `$drawer.__yui_focus_release__`.
-  `close_drawer_one` invokes it. The `priv.drawer_focus_states` Map
-  is gone too.
-- `tests/shell_focus_trap.test.mjs`: 10 unit tests with hand-rolled
-  DOM stubs (no extra devDep). Brings the parser+focus-trap unit
-  total to 23/23.
-
-### Shell-level helpers → `src/shell_modals.js`
-Naming convention: `yui_shell_show_*` for non-blocking,
-`yui_shell_confirm_*` for blocking dialogs that resolve a Promise.
-- **Non-blocking**: `yui_shell_show_info`, `yui_shell_show_warning`,
-  `yui_shell_show_error`, `yui_shell_show_modal`. Toasts auto-
-  dismiss after `opts.timeout` ms (default 5000; `0` disables).
-  Each returns a `{ close() }` handle.
-- **Blocking**: `yui_shell_confirm_ok`, `yui_shell_confirm_yesno`,
-  `yui_shell_confirm_yesnocancel`. Each returns a Promise that
-  resolves with the user's choice (`undefined` / boolean /
-  `"yes"|"no"|"cancel"` respectively). Escape, the close button
-  and click on the background all resolve with the LAST button's
-  value (cancel/no/ok — safe-default convention).
-- Every modal/dialog automatically pushes a close handler onto the
-  Escape priority chain (§11) and installs a focus-trap on the
-  modal card. `Tab`/`Shift+Tab` cycle inside, focus is restored on
-  close.
-- All seven re-exported from `@yuneta/lib-yui`.
-
-### Smoke entries in the test-app
-`app_config.json` toolbar grew two items: `Hello` (fires
-`EV_SHOW_HELLO` → `yui_shell_show_info`) and `Ask` (fires
-`EV_ASK_QUESTION` → `yui_shell_confirm_yesno` + a follow-up info
-toast). The `c_test_lang` controller picked up the two new
-actions/events. No new gobj.
-
-### e2e (`tests-e2e/modals.spec.mjs`)
-Four tests × 2 browsers = 8 new e2e tests:
-- Hello toolbar item paints a `.notification` on the notification
-  layer; clicking the `.delete` button dismisses.
-- Ask toolbar item opens a yes/no dialog; clicking *Yes* resolves
-  the Promise and shows the follow-up toast.
-- Escape on an open dialog dismisses with the last button's value
-  (= the *No* answer in this case).
-- **Modal over drawer**: open the drawer, then open a modal on top
-  of it (synthetic click bypasses the drawer's pointer occlusion);
-  first Escape closes the modal, the drawer remains open; second
-  Escape closes the drawer. This is the cross-overlay test that
-  was deferred from #3.
-
-### Drift policy
-Documented in `SHELL.md §10`: legacy `display_*` / `get_yes*` /
-`get_ok` bug fixes are NOT back-ported to `yui_shell_show_*` /
-`yui_shell_confirm_*` and vice versa. The two stacks are
-parallel.
-
-Tests: parser + focus-trap 23/23, e2e 26/26 (chromium + firefox).
-
----
-
-## 5. Generalise the secondary-nav loop beyond `menu.primary` — DONE
-
-`instantiate_menus` now walks every menu mounted via a `"menu.<id>"`
-host whose items declare a `submenu` with its own `render`. The
-synthesised secondary `menu_id` is
-`secondary.<owning_menu_id>.<item.id>`, scoped to the owning menu so
-two primary-style menus can share item ids without colliding.
-
-`update_secondary_nav_visibility` reads `entry.menu_id` (the route
-owner) and computes `target_secondary_id =
-secondary.<entry.menu_id>.<active_primary_id>`. The matching nav
-shows; every other secondary hides. Cross-menu duplicates of the
-same item id are independent.
-
-The previous limitation in `SHELL.md` §11.1 has been removed; §6
-gained a small "Secondary nav `menu_id`" subsection documenting the
-synthesised id.
-
-A new preset `app_config_multimenu.json` declares two primary-style
-menus side-by-side (`menu.primary` in `left/bottom`, `menu.admin` in
-`right/bottom-sub`) with the same item id (`dash`) in each; the e2e
-test `tests-e2e/multimenu.spec.mjs` boots that preset and verifies:
-
-- Both primary navs are rendered, each with its own `aria-label`.
-- The shell auto-instantiates one secondary nav per (menu × item
-  with submenu.render).
-- On the default route (`/dash/ov`, owned by `menu.primary`),
-  `menu.primary`'s secondary nav is visible; `menu.admin`'s is
-  hidden.
-- Navigating to `/admin/dash/users` flips the visibility — strictly
-  by `menu_id`, not by the duplicated `dash` item id.
-- The active secondary's items belong to the right tree and the
-  other tree's routes are absent.
-
-Tests: parser + focus-trap 23/23, e2e 28/28 (chromium + firefox).
-
----
-
-## 6. End-to-end smoke with Playwright
-
-Today the only automated coverage is the 13 `shell_show_on`
-parser tests — Playwright wraps the actual UI.
-
-### Done in the first pass
-- `playwright.config.js` boots the test-app via `vite preview`
-  against the built bundle on port 5181 (chromium + firefox +
-  webkit, `webServer` auto-starts before tests).
-- `npm run test:e2e` / `npm run test:e2e:ui` / `npm run test:all`
-  wired up.
-- `.github/workflows/lib-yui.yml` runs unit + e2e on PRs and on
-  `main` touching `kernel/js/lib-yui/**` or `kernel/js/gobj-js/**`.
-  Uploads the Playwright HTML report on failure.
-- `tests-e2e/boot.spec.mjs`:
-    * default preset lands on `/dash/ov` with the Overview card,
-      the URL hash mirrors the route, the primary nav has its
-      active item, and the boot is console-error-clean.
-    * accordion preset auto-expands the Dashboard branch
-      (`aria-expanded="true"`) and lands on Overview.
-- `tests-e2e/navigation.spec.mjs`:
-    * clicks each primary item, asserts the URL hash and the
-      centre-stage card title.
-    * typed-URL hash navigation lands on the right card.
-    * back/forward replays the route history.
-    * submenu container `/dash` redirects to `/dash/ov`.
-
-### Done in the second pass (this branch)
-- `tests-e2e/drawer.spec.mjs` (3) — burger+Escape+focus restore;
-  backdrop closes via canonical path; Escape with stack empty.
-- `tests-e2e/modals.spec.mjs` (4) — info toast; yes/no dialog;
-  Escape dismisses; modal-over-drawer escape order.
-- `tests-e2e/multimenu.spec.mjs` (1) — two primary-style menus,
-  cross-menu secondary scoping.
-- `tests-e2e/validator.spec.mjs` (1) — invalid preset surfaces
-  the banner and the matching console errors.
-- `tests-e2e/lifecycle.spec.mjs` (3) — keep_alive reuses
-  instance, lazy_destroy mints a new one, eager is
-  preinstantiated.
-- `tests-e2e/breakpoint.spec.mjs` (3) — desktop: left vertical
-  + no bottom; mobile: bottom icon-bar + no left; tablet:
-  toolbar appears.
-- `tests-e2e/i18n.spec.mjs` (1) — ES/EN button flips every
-  translatable label and preserves the active highlight.
-
-**Done when:** CI green on the branch with every spec above.
-22 specs × 3 browsers (chromium + firefox + webkit) = 69 e2e tests,
-all green locally on Linux after running
-`./install-e2e-deps.sh`.
-
-### Acknowledged debt (not blocking the merge)
-
-- **Focus-trap unit tests use hand-rolled DOM stubs.**  Acceptable
-  while the trap stays simple and the stubs cover every branch
-  (Tab / Shift+Tab / non-Tab key / focus-from-outside / release
-  idempotency / missing panel / empty panel).  Switch to `jsdom`
-  or `happy-dom` if a real edge case appears (Shadow DOM, `inert`,
-  native `<dialog>`, `tabindex` derived from CSS, etc.).
-
----
-
-## 7. Open PR + run `/ultrareview` before merging to `main`
-
-Convention: feature branches are independently reviewed before
-they land.
-
-- Open the PR `claude/refactor-gui-system-qptVn → main` once tasks
-  #1–#6 are at a place where merging is desirable (does not
-  require every task to be done — at minimum #1 + #2 close the
-  original review scope).
-- The user runs `/ultrareview <PR#>` for a multi-agent independent
-  review.
-- Triage findings into either: (a) immediate fixes on the same PR;
-  (b) follow-ups appended to this TODO.
-- Squash-merge with the PR description summarising the entire
-  thread.
-- Delete the feature branch after merge.
-
-**Done when:** the PR is merged and the branch is deleted.
-
----
-
-## 8. (Optional, deferred) Migrate legacy GUIs off `C_YUI_MAIN` / `C_YUI_ROUTING`
+## 2. (Optional, deferred) Migrate legacy GUIs off `C_YUI_MAIN` / `C_YUI_ROUTING`
 
 > **Status: not planned.**  Captured here as a reference checklist
 > for whoever decides to take it on later.  Until that decision is
@@ -320,7 +34,7 @@ they land.
 
 The work needed if the decision is reversed:
 
-### 8.1. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
+### 2.1. Migrate `C_YUI_TABS` from `EV_ROUTING_CHANGED` to `EV_ROUTE_CHANGED`
 
 `C_YUI_TABS.ac_show` / `ac_hide` listen to `EV_ROUTING_CHANGED` of
 `C_YUI_ROUTING`.  Move that subscription to the shell's
@@ -333,7 +47,7 @@ The work needed if the decision is reversed:
   not set, so the migration can land before consumers are converted.
 - Add a small test-app stage that uses tabs to confirm.
 
-### 8.2. Inventory the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
+### 2.2. Inventory the remaining `C_YUI_ROUTING` / `C_YUI_MAIN` consumers
 
 ```
 grep -r register_c_yui_main      kernel/ utils/ yunos/
@@ -354,12 +68,12 @@ Likely consumers inside `lib-yui`:
 For each consumer:
 
 - Replace `EV_ROUTING_CHANGED` subscription with `EV_ROUTE_CHANGED`
-  via the shell (see 8.1).
+  via the shell (see 2.1).
 - Replace `display_*` / `get_yes*` calls with the shell-helper
-  version (#4: `yui_shell_show_*` / `yui_shell_confirm_*`).
+  version (`yui_shell_show_*` / `yui_shell_confirm_*`).
 - Drop the dependency on the old gclasses from imports.
 
-### 8.3. Migrate `estadodelaire/gui` to the shell — first real-world test
+### 2.3. Migrate `estadodelaire/gui` to the shell — first real-world test
 
 The companion repo `artgins/estadodelaire` is the canonical app on
 top of `lib-yui`.  Replace its bootstrap:
@@ -389,9 +103,9 @@ top of `lib-yui`.  Replace its bootstrap:
   **before continuing**.  Do not patch around it ad-hoc inside
   `gui/`.
 
-### 8.4. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
+### 2.4. Delete `C_YUI_MAIN` and `C_YUI_ROUTING` from `lib-yui`
 
-Gated on 8.1, 8.2, 8.3.  All four greps above must return empty.
+Gated on 2.1, 2.2, 2.3.  All four greps above must return empty.
 
 - Delete `src/c_yui_main.js`, `src/c_yui_main.css`,
   `src/c_yui_routing.js`, `src/c_yui_routing.css`.
@@ -405,5 +119,16 @@ Gated on 8.1, 8.2, 8.3.  All four greps above must return empty.
 - Bump `lib-yui` to `8.0.0` (breaking change).  Add CHANGELOG entry
   with the removal and link to this TODO.
 
-**Done when (8 as a whole):** `lib-yui` no longer ships either
+**Done when (2 as a whole):** `lib-yui` no longer ships either
 gclass and no consumer inside the org references them.
+
+---
+
+## Acknowledged debt (not blocking anything)
+
+- **Focus-trap unit tests use hand-rolled DOM stubs.**  Stubs cover
+  every branch of the trap (Tab / Shift+Tab / non-Tab / focus-from-
+  outside / release idempotency / missing panel / empty panel / LIFO
+  stacking).  Switch to `jsdom` or `happy-dom` only if a real edge
+  case appears (Shadow DOM, `inert`, native `<dialog>`, `tabindex`
+  derived from CSS, etc.).

--- a/kernel/js/lib-yui/TODO.md
+++ b/kernel/js/lib-yui/TODO.md
@@ -191,25 +191,41 @@ Tests: parser + focus-trap 23/23, e2e 26/26 (chromium + firefox).
 
 ---
 
-## 5. Generalise the secondary-nav loop beyond `menu.primary`
+## 5. Generalise the secondary-nav loop beyond `menu.primary` — DONE
 
-`instantiate_menus()` in `c_yui_shell.js` walks only
-`menus.primary.items[*].submenu` to build level-2 navs.  See
-[`SHELL.md` §11.1](./SHELL.md).
+`instantiate_menus` now walks every menu mounted via a `"menu.<id>"`
+host whose items declare a `submenu` with its own `render`. The
+synthesised secondary `menu_id` is
+`secondary.<owning_menu_id>.<item.id>`, scoped to the owning menu so
+two primary-style menus can share item ids without colliding.
 
-- Walk every menu mounted via a zone host of the form `"menu.<id>"`
-  whose items declare a `submenu`, not just `primary`.  The
-  `secondary.<item.id>` synthesised id stays unique because item
-  ids are scoped to their parent menu — but if collisions across
-  menus become a concern, switch to
-  `secondary.<menu_id>.<item.id>`.
-- Update `SHELL.md` §11 to drop limitation #1 (and renumber).
-- Add a regression case to the test-app: a second primary-style
-  menu (e.g. `menu.admin`) with its own submenus, and verify the
-  right secondary nav surfaces under the right primary.
+`update_secondary_nav_visibility` reads `entry.menu_id` (the route
+owner) and computes `target_secondary_id =
+secondary.<entry.menu_id>.<active_primary_id>`. The matching nav
+shows; every other secondary hides. Cross-menu duplicates of the
+same item id are independent.
 
-**Done when:** the test-app has at least two primary-style menus
-with submenus and both render their secondary navs correctly.
+The previous limitation in `SHELL.md` §11.1 has been removed; §6
+gained a small "Secondary nav `menu_id`" subsection documenting the
+synthesised id.
+
+A new preset `app_config_multimenu.json` declares two primary-style
+menus side-by-side (`menu.primary` in `left/bottom`, `menu.admin` in
+`right/bottom-sub`) with the same item id (`dash`) in each; the e2e
+test `tests-e2e/multimenu.spec.mjs` boots that preset and verifies:
+
+- Both primary navs are rendered, each with its own `aria-label`.
+- The shell auto-instantiates one secondary nav per (menu × item
+  with submenu.render).
+- On the default route (`/dash/ov`, owned by `menu.primary`),
+  `menu.primary`'s secondary nav is visible; `menu.admin`'s is
+  hidden.
+- Navigating to `/admin/dash/users` flips the visibility — strictly
+  by `menu_id`, not by the duplicated `dash` item id.
+- The active secondary's items belong to the right tree and the
+  other tree's routes are absent.
+
+Tests: parser + focus-trap 23/23, e2e 28/28 (chromium + firefox).
 
 ---
 

--- a/kernel/js/lib-yui/index.js
+++ b/kernel/js/lib-yui/index.js
@@ -32,6 +32,15 @@ export {
     yui_shell_pop_escape,
 } from "./src/c_yui_shell.js";
 export { register_c_yui_nav } from "./src/c_yui_nav.js";
+export {
+    yui_shell_show_info,
+    yui_shell_show_warning,
+    yui_shell_show_error,
+    yui_shell_show_modal,
+    yui_shell_confirm_ok,
+    yui_shell_confirm_yesno,
+    yui_shell_confirm_yesnocancel,
+} from "./src/shell_modals.js";
 
 /*
  *  TreeDB components

--- a/kernel/js/lib-yui/index.js
+++ b/kernel/js/lib-yui/index.js
@@ -28,6 +28,8 @@ export {
     yui_shell_open_drawer,
     yui_shell_close_drawer,
     yui_shell_toggle_drawer,
+    yui_shell_push_escape,
+    yui_shell_pop_escape,
 } from "./src/c_yui_shell.js";
 export { register_c_yui_nav } from "./src/c_yui_nav.js";
 

--- a/kernel/js/lib-yui/install-e2e-deps.sh
+++ b/kernel/js/lib-yui/install-e2e-deps.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# install-e2e-deps.sh — install everything Playwright needs to run the
+# lib-yui end-to-end test suite locally on Linux.
+#
+# Browsers (Chromium / Firefox / WebKit) are downloaded by Playwright
+# itself; system libraries the WebKit build links against are not
+# bundled and must be installed via apt.  Chromium and Firefox bundle
+# all their deps, so this script only has to cover WebKit.
+#
+# Run it once after `npm install`:
+#
+#       cd kernel/js/lib-yui
+#       npm install
+#       ./install-e2e-deps.sh
+#       npm run test:e2e
+#
+# After this, `npm run test:e2e` works without any sudo prompt.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
+if [ ! -d node_modules/@playwright ]; then
+    echo "ERROR: @playwright/test not installed.  Run 'npm install' first." >&2
+    exit 1
+fi
+
+echo "[1/2] Installing Playwright browser binaries (chromium, firefox, webkit) — no sudo needed..."
+npx playwright install chromium firefox webkit
+
+echo "[2/2] Installing apt deps WebKit links against (libgstreamer-plugins-bad1.0-0, libavif16, ...) — needs sudo..."
+sudo npx playwright install-deps webkit
+
+echo
+echo "Done.  Run the suite with:"
+echo "    npm run test:e2e"

--- a/kernel/js/lib-yui/package.json
+++ b/kernel/js/lib-yui/package.json
@@ -24,10 +24,14 @@
     "scripts": {
         "build": "vite build",
         "test": "node --test tests/*.test.mjs",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
+        "test:all": "npm test && npm run test:e2e",
         "prepublishOnly": "npm run build"
     },
     "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",
+        "@playwright/test": "^1.49.0",
         "vite": "^8.0.10"
     },
     "peerDependencies": {

--- a/kernel/js/lib-yui/playwright.config.js
+++ b/kernel/js/lib-yui/playwright.config.js
@@ -1,0 +1,57 @@
+/***********************************************************************
+ *          playwright.config.js
+ *
+ *      End-to-end smoke harness for C_YUI_SHELL + C_YUI_NAV.
+ *      Boots the test-app via `vite preview` against its built bundle
+ *      (deterministic — no HMR, no source watching) and runs the specs
+ *      under `tests-e2e/` against chromium and firefox.
+ *
+ *      Run locally:
+ *          npm run test:e2e           # headless, both browsers
+ *          npm run test:e2e:ui        # Playwright UI mode
+ *
+ *      The first run downloads the browser binaries:
+ *          npx playwright install chromium firefox
+ *
+ *          Copyright (c) 2026, ArtGins.
+ *          All Rights Reserved.
+ ***********************************************************************/
+import { defineConfig, devices } from "@playwright/test";
+
+const E2E_PORT = 5181;
+const E2E_BASE = `http://localhost:${E2E_PORT}/`;
+
+export default defineConfig({
+    testDir: "./tests-e2e",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? "github" : "list",
+
+    use: {
+        baseURL: E2E_BASE,
+        trace: "on-first-retry"
+    },
+
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] }
+        },
+        {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] }
+        }
+    ],
+
+    /*  Build the test-app once and serve it via vite preview. The dev
+     *  server (port 5180) is intentionally NOT used — preview is more
+     *  deterministic and matches what users actually ship. */
+    webServer: {
+        command: `cd test-app && npm run build && npm run preview -- --port ${E2E_PORT} --strictPort`,
+        url: E2E_BASE,
+        timeout: 120_000,
+        reuseExistingServer: !process.env.CI
+    }
+});

--- a/kernel/js/lib-yui/playwright.config.js
+++ b/kernel/js/lib-yui/playwright.config.js
@@ -7,11 +7,11 @@
  *      under `tests-e2e/` against chromium and firefox.
  *
  *      Run locally:
- *          npm run test:e2e           # headless, both browsers
+ *          npm run test:e2e           # headless, all three browsers
  *          npm run test:e2e:ui        # Playwright UI mode
  *
  *      The first run downloads the browser binaries:
- *          npx playwright install chromium firefox
+ *          npx playwright install chromium firefox webkit
  *
  *          Copyright (c) 2026, ArtGins.
  *          All Rights Reserved.
@@ -42,6 +42,10 @@ export default defineConfig({
         {
             name: "firefox",
             use: { ...devices["Desktop Firefox"] }
+        },
+        {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] }
         }
     ],
 

--- a/kernel/js/lib-yui/run-tests.sh
+++ b/kernel/js/lib-yui/run-tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# run-tests.sh — run every lib-yui test (unit + e2e) in one shot.
+#
+#       cd kernel/js/lib-yui
+#       ./run-tests.sh                 # full matrix
+#       ./run-tests.sh --unit          # parser + focus-trap only
+#       ./run-tests.sh --e2e           # Playwright only
+#       ./run-tests.sh --browser=chromium
+#
+# Prerequisites:
+#       npm install
+#       ./install-e2e-deps.sh          # browsers + apt deps for webkit
+#
+# The script always runs from this directory, regardless of where it
+# was invoked.  Exits non-zero on the first failure.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+cd "$SCRIPT_DIR"
+
+run_unit=1
+run_e2e=1
+e2e_args=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --unit)
+            run_e2e=0
+            ;;
+        --e2e)
+            run_unit=0
+            ;;
+        --browser=*)
+            e2e_args="$e2e_args --project=${arg#--browser=}"
+            ;;
+        --help|-h)
+            sed -n '2,16p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ ! -d node_modules ]; then
+    echo "ERROR: node_modules missing.  Run 'npm install' first." >&2
+    exit 1
+fi
+
+if [ "$run_unit" = "1" ]; then
+    echo "============================================================"
+    echo " Unit tests (node --test) — parser + focus-trap"
+    echo "============================================================"
+    npm test
+fi
+
+if [ "$run_e2e" = "1" ]; then
+    if [ ! -d node_modules/@playwright ]; then
+        echo "ERROR: @playwright/test not installed.  Run 'npm install'." >&2
+        exit 1
+    fi
+    echo
+    echo "============================================================"
+    echo " End-to-end tests (Playwright) — chromium + firefox + webkit"
+    echo "============================================================"
+    # shellcheck disable=SC2086
+    npx playwright test $e2e_args --reporter=list
+fi
+
+echo
+echo "All requested tests passed."

--- a/kernel/js/lib-yui/src/c_yui_nav.js
+++ b/kernel/js/lib-yui/src/c_yui_nav.js
@@ -481,13 +481,16 @@ function wire_clicks(gobj, $root)
             return;
         }
 
-        /*  Drawer backdrop close. */
+        /*  Drawer backdrop close.  Don't mutate the DOM directly —
+         *  the shell owns the drawer state (focus-trap, escape
+         *  stack) and must run its full close path.  Publish the
+         *  intent and let the shell handle it through
+         *  ac_drawer_close_requested. */
         let $bk = target.closest("[data-close-drawer]");
         if($bk) {
-            let $drawer = $bk.closest(".yui-drawer");
-            if($drawer) {
-                $drawer.classList.remove("is-active");
-            }
+            gobj_publish_event(gobj, "EV_DRAWER_CLOSE_REQUESTED", {
+                menu_id: gobj_read_attr(gobj, "menu_id") || ""
+            });
             ev.preventDefault();
             return;
         }
@@ -645,8 +648,9 @@ function create_gclass(gclass_name)
     ];
 
     const event_types = [
-        ["EV_ROUTE_CHANGED", 0],
-        ["EV_NAV_CLICKED",   event_flag_t.EVF_OUTPUT_EVENT|event_flag_t.EVF_PUBLIC_EVENT]
+        ["EV_ROUTE_CHANGED",          0],
+        ["EV_NAV_CLICKED",            event_flag_t.EVF_OUTPUT_EVENT|event_flag_t.EVF_PUBLIC_EVENT],
+        ["EV_DRAWER_CLOSE_REQUESTED", event_flag_t.EVF_OUTPUT_EVENT|event_flag_t.EVF_PUBLIC_EVENT]
     ];
 
     __gclass__ = gclass_create(

--- a/kernel/js/lib-yui/src/c_yui_nav.js
+++ b/kernel/js/lib-yui/src/c_yui_nav.js
@@ -573,9 +573,19 @@ function ac_route_changed(gobj, event, kw, src)
     /*  Decide which id we highlight:
      *      primary nav highlights parent_item (or item if top-level)
      *      secondary nav highlights the leaf item
-     */
+     *
+     *  Multi-menu scoping: primary navs short-circuit when the
+     *  route's owning menu differs from this nav's menu — two
+     *  primary-style menus that share an item id (legitimate per
+     *  TODO #5) must NOT cross-highlight.  Treat empty kw.menu_id
+     *  as a permissive match for backwards compatibility with
+     *  pre-TODO #5 callers. */
     let id_to_mark = null;
     if(level === "primary") {
+        let nav_menu_id = gobj_read_attr(gobj, "menu_id") || "";
+        if(kw.menu_id && nav_menu_id && nav_menu_id !== kw.menu_id) {
+            return 0;
+        }
         id_to_mark = parent_item ? parent_item.id : (item && item.id);
     } else {
         id_to_mark = item && item.id;

--- a/kernel/js/lib-yui/src/c_yui_nav.js
+++ b/kernel/js/lib-yui/src/c_yui_nav.js
@@ -23,7 +23,7 @@
 
 import {
     SDATA, SDATA_END, data_type_t, event_flag_t,
-    gclass_create, log_error,
+    gclass_create, log_error, log_warning,
     gobj_subscribe_event,
     gobj_parent,
     gobj_read_attr, gobj_read_pointer_attr, gobj_write_attr,
@@ -109,7 +109,9 @@ function mt_start(gobj)
          *  the active item. */
         try {
             gobj_subscribe_event(shell, "EV_ROUTE_CHANGED", {}, gobj);
-        } catch(e) { /* already subscribed, ignore */ }
+        } catch(e) {
+            log_warning(`C_YUI_NAV: subscribe to EV_ROUTE_CHANGED failed: ${e}`);
+        }
     }
 }
 

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -317,9 +317,16 @@ function validate_config(config)
         log_error("C_YUI_SHELL: config.menu must be an object");
         ok = false;
     }
-    if(config.toolbar !== undefined && !is_array(config.toolbar)) {
-        log_error("C_YUI_SHELL: config.toolbar must be an array");
-        ok = false;
+    if(config.toolbar !== undefined) {
+        /*  toolbar = { zone?, aria_label?, items[] } — see SHELL.md §3.4. */
+        if(!is_object(config.toolbar)) {
+            log_error("C_YUI_SHELL: config.toolbar must be an object");
+            ok = false;
+        } else if(config.toolbar.items !== undefined &&
+                  !is_array(config.toolbar.items)) {
+            log_error("C_YUI_SHELL: config.toolbar.items must be an array");
+            ok = false;
+        }
     }
 
     return ok;
@@ -696,7 +703,7 @@ function navigate_to(gobj, route)
      *  validation or DOM work. This guarantees that the FSM trace and
      *  any subscribed auditor see every requested route — including
      *  rerouted submenu defaults and routes that ultimately fail. */
-    gobj_publish_event(gobj, "EV_NAVIGATION_REQUESTED", {
+    gobj_publish_event(gobj, "EV_ROUTE_REQUESTED", {
         route: route,
         from:  gobj_read_attr(gobj, "current_route") || ""
     });
@@ -1291,16 +1298,17 @@ function create_gclass(gclass_name)
     ];
 
     const event_types = [
-        ["EV_NAV_CLICKED",          0],
+        ["EV_NAV_CLICKED",     0],
         /*  Audit witness: every navigation attempt publishes this BEFORE
          *  any work is done, so the FSM trace records intent regardless
-         *  of whether the route resolves successfully. */
-        ["EV_NAVIGATION_REQUESTED", event_flag_t.EVF_OUTPUT_EVENT
-                                   |event_flag_t.EVF_PUBLIC_EVENT
-                                   |event_flag_t.EVF_NO_WARN_SUBS],
-        ["EV_ROUTE_CHANGED",        event_flag_t.EVF_OUTPUT_EVENT
-                                   |event_flag_t.EVF_PUBLIC_EVENT
-                                   |event_flag_t.EVF_NO_WARN_SUBS]
+         *  of whether the route resolves successfully.  Pairs with
+         *  EV_ROUTE_CHANGED (the corresponding fact event). */
+        ["EV_ROUTE_REQUESTED", event_flag_t.EVF_OUTPUT_EVENT
+                              |event_flag_t.EVF_PUBLIC_EVENT
+                              |event_flag_t.EVF_NO_WARN_SUBS],
+        ["EV_ROUTE_CHANGED",   event_flag_t.EVF_OUTPUT_EVENT
+                              |event_flag_t.EVF_PUBLIC_EVENT
+                              |event_flag_t.EVF_NO_WARN_SUBS]
     ];
 
     __gclass__ = gclass_create(

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -142,7 +142,7 @@ function mt_start(gobj)
         if($base) {
             $base.appendChild(createElement2(
                 ["div", {class: "notification is-danger m-4"},
-                    ["p", "C_YUI_SHELL: invalid config — see browser console for details"]
+                    ["p", {}, "C_YUI_SHELL: invalid config — see browser console for details"]
                 ]
             ));
         }
@@ -305,11 +305,24 @@ function validate_config(config)
     }
 
     let zones_cfg = is_object(shell_cfg.zones) ? shell_cfg.zones : {};
+    /*  host syntax: must be one of "toolbar", "menu.<id>", "stage.<id>". */
+    let HOST_RE = /^(?:toolbar|menu\.\S+|stage\.\S+)$/;
     for(let zid in zones_cfg) {
         if(ZONE_IDS.indexOf(zid) < 0) {
             log_error(
                 `C_YUI_SHELL: unknown zone '${zid}' in config.shell.zones; ` +
                 `valid zones: ${ZONE_IDS.join(", ")}`
+            );
+            ok = false;
+            continue;
+        }
+        let z = zones_cfg[zid];
+        if(z && typeof z.host === "string" && z.host.length > 0 &&
+                !HOST_RE.test(z.host))
+        {
+            log_error(
+                `C_YUI_SHELL: zone '${zid}' has invalid host '${z.host}'; ` +
+                `must match 'toolbar', 'menu.<id>' or 'stage.<id>'`
             );
             ok = false;
         }
@@ -329,6 +342,17 @@ function validate_config(config)
                 `C_YUI_SHELL: stage '${sname}' references unknown zone '${zone}'`
             );
             ok = false;
+            continue;
+        }
+        /*  zone must actually be declared in shell.zones — catches typos
+         *  like stages.main.zone = "centre" that pass the ZONE_IDS test
+         *  by accident. */
+        if(!Object.prototype.hasOwnProperty.call(zones_cfg, zone)) {
+            log_warning(
+                `C_YUI_SHELL: stage '${sname}' references zone '${zone}' ` +
+                `which is not declared in config.shell.zones — it will be ` +
+                `created with default attributes`
+            );
         }
     }
 
@@ -348,7 +372,58 @@ function validate_config(config)
         }
     }
 
+    /*  Route uniqueness: a route declared in two different menus is a
+     *  source of subtle bugs (build_item_index has a "first wins"
+     *  rule, so the second declaration is silently shadowed).  Warn
+     *  loudly. */
+    if(is_object(config.menu)) {
+        let route_owner = {};
+        for(let menu_id in config.menu) {
+            let m = config.menu[menu_id];
+            if(!m || !is_array(m.items)) {
+                continue;
+            }
+            for(let it of m.items) {
+                check_route_unique(route_owner, it, menu_id);
+                if(it.submenu && is_array(it.submenu.items)) {
+                    for(let sub of it.submenu.items) {
+                        check_route_unique(route_owner, sub, menu_id);
+                    }
+                }
+            }
+        }
+    }
+
     return ok;
+}
+
+/************************************************************
+ *  Helper for validate_config — only warn when TWO different
+ *  menus both declare a `target` for the same route.  Items
+ *  without a `target` are just navigators (they delegate to
+ *  whichever menu owns the route) and do not compete, so the
+ *  legitimate "menu A navigates / menu B owns" pattern stays
+ *  silent.
+ ************************************************************/
+function check_route_unique(route_owner, item, menu_id)
+{
+    if(!item || empty_string(item.route)) {
+        return;
+    }
+    if(!item.target) {
+        return;
+    }
+    let route = item.route;
+    if(route_owner[route] !== undefined && route_owner[route] !== menu_id) {
+        log_warning(
+            `C_YUI_SHELL: route '${route}' has a target in menu ` +
+            `'${menu_id}' AND in menu '${route_owner[route]}' — the ` +
+            `second target is shadowed (build_item_index keeps the ` +
+            `first entry that owns a target)`
+        );
+        return;
+    }
+    route_owner[route] = menu_id;
 }
 
 /************************************************************

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -41,6 +41,10 @@ import {
     bulma_hidden_class,
 } from "./shell_show_on.js";
 
+import {
+    activate_focus_trap_on,
+} from "./shell_focus_trap.js";
+
 /***************************************************************
  *              Constants
  ***************************************************************/
@@ -1049,84 +1053,6 @@ function drawers(gobj, menu_id)
 }
 
 /************************************************************
- *  Focus-trap for an open drawer:
- *      - on activate: save document.activeElement, install a
- *        keydown trap that cycles Tab/Shift+Tab inside the
- *        panel, move focus to the first focusable child.
- *      - on release: remove the trap and restore focus.
- *  State is kept per-drawer in priv.drawer_focus_states so
- *  multiple drawers (rare but legal) work independently.
- ************************************************************/
-const FOCUSABLE_SELECTOR =
-    'a[href], button:not([disabled]), input:not([disabled]),' +
-    ' select:not([disabled]), textarea:not([disabled]),' +
-    ' [tabindex]:not([tabindex="-1"])';
-
-function activate_focus_trap(gobj, $drawer)
-{
-    let priv = gobj_read_attr(gobj, "priv");
-    if(!priv) {
-        return;
-    }
-    if(!priv.drawer_focus_states) {
-        priv.drawer_focus_states = new Map();
-    }
-    if(priv.drawer_focus_states.has($drawer)) {
-        return;
-    }
-    let saved = document.activeElement;
-    let panel = $drawer.querySelector(".yui-drawer-panel") || $drawer;
-
-    let trap = ev => {
-        if(ev.key !== "Tab") {
-            return;
-        }
-        let nodes = panel.querySelectorAll(FOCUSABLE_SELECTOR);
-        if(nodes.length === 0) {
-            return;
-        }
-        let first = nodes[0];
-        let last = nodes[nodes.length - 1];
-        let inside = panel.contains(document.activeElement);
-        if(ev.shiftKey) {
-            if(!inside || document.activeElement === first) {
-                last.focus();
-                ev.preventDefault();
-            }
-        } else {
-            if(!inside || document.activeElement === last) {
-                first.focus();
-                ev.preventDefault();
-            }
-        }
-    };
-    document.addEventListener("keydown", trap, true);
-    priv.drawer_focus_states.set($drawer, { saved: saved, trap: trap, panel: panel });
-
-    let first = panel.querySelector(FOCUSABLE_SELECTOR);
-    if(first && typeof first.focus === "function") {
-        first.focus();
-    }
-}
-
-function release_focus_trap(gobj, $drawer)
-{
-    let priv = gobj_read_attr(gobj, "priv");
-    if(!priv || !priv.drawer_focus_states) {
-        return;
-    }
-    let st = priv.drawer_focus_states.get($drawer);
-    if(!st) {
-        return;
-    }
-    document.removeEventListener("keydown", st.trap, true);
-    priv.drawer_focus_states.delete($drawer);
-    if(st.saved && typeof st.saved.focus === "function" && document.body.contains(st.saved)) {
-        st.saved.focus();
-    }
-}
-
-/************************************************************
  *  Escape priority chain helpers — push/pop a {layer, handler}
  *  record on `priv.escape_stack`.  Escape calls the top entry
  *  only and consumes the event; LIFO ordering naturally matches
@@ -1154,10 +1080,13 @@ function pop_escape(gobj, handler)
     }
 }
 
-/*  Per-drawer open/close.  The handler reference is parked on the
- *  $drawer DOM element so any close path (Escape, backdrop click,
- *  toolbar action, public yui_shell_close_drawer) ends up popping
- *  the correct stack entry. */
+/*  Per-drawer open/close.  The escape-stack entry and the focus-
+ *  trap release function are parked on the $drawer DOM element so
+ *  any close path (Escape, backdrop click, toolbar action, public
+ *  yui_shell_close_drawer) tears them down through the same code.
+ *
+ *  The actual focus-trap is the generic helper from
+ *  shell_focus_trap.js — same module modals/popups use. */
 function open_drawer_one(gobj, $c)
 {
     if($c.classList.contains("is-active")) {
@@ -1167,7 +1096,8 @@ function open_drawer_one(gobj, $c)
     $c.__yui_close_handler__ = close_fn;
     push_escape(gobj, "overlay", close_fn);
     $c.classList.add("is-active");
-    activate_focus_trap(gobj, $c);
+    let panel = $c.querySelector(".yui-drawer-panel") || $c;
+    $c.__yui_focus_release__ = activate_focus_trap_on(panel);
 }
 
 function close_drawer_one(gobj, $c)
@@ -1176,7 +1106,10 @@ function close_drawer_one(gobj, $c)
         return;
     }
     $c.classList.remove("is-active");
-    release_focus_trap(gobj, $c);
+    if($c.__yui_focus_release__) {
+        $c.__yui_focus_release__();
+        $c.__yui_focus_release__ = null;
+    }
     if($c.__yui_close_handler__) {
         pop_escape(gobj, $c.__yui_close_handler__);
         $c.__yui_close_handler__ = null;

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -571,13 +571,21 @@ function instantiate_menus(gobj, config)
         }
     }
 
-    /*  Secondary navs: create one per primary item that has a submenu,
-     *  for each zone listed in submenu.render. Initially hidden, shown
-     *  when the primary item becomes active.
-     */
-    let primary = menus.primary;
-    if(primary && is_array(primary.items)) {
-        for(let item of primary.items) {
+    /*  Secondary navs: create one per primary-style menu item that
+     *  declares a submenu with its own render block, for every zone
+     *  listed in `submenu.render`.  Initially hidden, shown when the
+     *  owning primary item becomes active.
+     *
+     *  We walk every menu mounted via a zone host of the form
+     *  "menu.<id>" — not just menus.primary.  The synthesized
+     *  sub_menu_id is `secondary.<menu_id>.<item.id>` so two
+     *  menus can have items with the same id without colliding. */
+    for(let menu_id in zones_for_menu) {
+        let menu = menus[menu_id];
+        if(!menu || !is_array(menu.items)) {
+            continue;
+        }
+        for(let item of menu.items) {
             let sub = item.submenu;
             if(!sub || !is_array(sub.items)) {
                 continue;
@@ -589,19 +597,22 @@ function instantiate_menus(gobj, config)
                 }
                 let layout = render_by_zone[zone_id];
                 if(!priv.zones[zone_id]) {
-                    log_warning(`C_YUI_SHELL: submenu renders in unknown zone '${zone_id}'`);
+                    log_warning(
+                        `C_YUI_SHELL: submenu of '${menu_id}.${item.id}' ` +
+                        `renders in unknown zone '${zone_id}'`
+                    );
                     continue;
                 }
                 let submenu_def = {
                     items: sub.items,
                     render: { [zone_id]: render_to_obj(layout) }
                 };
-                let sub_menu_id = `secondary.${item.id}`;
+                let sub_menu_id = `secondary.${menu_id}.${item.id}`;
                 let nav = instantiate_nav_in_zone(
                     gobj, submenu_def, sub_menu_id, zone_id, "secondary",
                     item.name || ""
                 );
-                /*  Hidden until primary is active. */
+                /*  Hidden until owning primary is active. */
                 let $c = gobj_read_attr(nav, "$container");
                 if($c) {
                     $c.classList.add("is-hidden");
@@ -1198,22 +1209,23 @@ function update_secondary_nav_visibility(gobj, entry)
     let active_primary_id = entry.parent_item
         ? entry.parent_item.id
         : entry.item.id;
+    let owning_menu_id = entry.menu_id || "";
+    let target_secondary_id = `secondary.${owning_menu_id}.${active_primary_id}`;
 
     for(let nav of priv.navs) {
         let level = gobj_read_attr(nav, "level");
         if(level !== "secondary") {
             continue;
         }
-        let menu_id = gobj_read_attr(nav, "menu_id") || "";
-        let m = /^secondary\.(.+)$/.exec(menu_id);
-        if(!m) {
+        let nav_menu_id = gobj_read_attr(nav, "menu_id") || "";
+        if(!nav_menu_id.startsWith("secondary.")) {
             continue;
         }
         let $c = gobj_read_attr(nav, "$container");
         if(!$c) {
             continue;
         }
-        if(m[1] === active_primary_id) {
+        if(nav_menu_id === target_secondary_id) {
             $c.classList.remove("is-hidden");
         } else {
             $c.classList.add("is-hidden");

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -125,6 +125,21 @@ function mt_start(gobj)
     let config = gobj_read_attr(gobj, "config") || {};
     let priv = gobj_read_attr(gobj, "priv");
 
+    /*  Validate the declarative config before anything reads it. This is a
+     *  system boundary (app-supplied JSON); validation makes shape errors
+     *  visible loudly instead of producing a half-built shell. */
+    if(!validate_config(config)) {
+        let $base = priv.layers && priv.layers.base;
+        if($base) {
+            $base.appendChild(createElement2(
+                ["div", {class: "notification is-danger m-4"},
+                    ["p", "C_YUI_SHELL: invalid config — see browser console for details"]
+                ]
+            ));
+        }
+        return;
+    }
+
     build_item_index(gobj, config);
     instantiate_menus(gobj, config);
     build_toolbar(gobj, config);
@@ -192,7 +207,12 @@ function mt_stop(gobj)
     }
 
     for(let nav of priv.navs) {
-        try { gobj_stop(nav); gobj_destroy(nav); } catch(e) { /* ignore */ }
+        try {
+            gobj_stop(nav);
+            gobj_destroy(nav);
+        } catch(e) {
+            log_warning(`C_YUI_SHELL: stop/destroy nav failed: ${e}`);
+        }
     }
     priv.navs = [];
 
@@ -200,7 +220,12 @@ function mt_stop(gobj)
         let st = priv.stages[name];
         for(let route in st.items) {
             let g = st.items[route];
-            try { gobj_stop(g); gobj_destroy(g); } catch(e) { /* ignore */ }
+            try {
+                gobj_stop(g);
+                gobj_destroy(g);
+            } catch(e) {
+                log_warning(`C_YUI_SHELL: stop/destroy view '${route}' failed: ${e}`);
+            }
         }
         st.items = {};
         st.active_route = null;
@@ -229,6 +254,76 @@ function mt_destroy(gobj)
 
 
 
+
+/************************************************************
+ *  Validate the declarative config (system boundary: app JSON).
+ *
+ *  Reports every missing/wrong field via log_error so a malformed
+ *  config fails loudly instead of producing an empty/broken shell.
+ *  Returns true iff the config is structurally usable.
+ ************************************************************/
+function validate_config(config)
+{
+    let ok = true;
+
+    if(!is_object(config)) {
+        log_error("C_YUI_SHELL: config must be a JSON object");
+        return false;
+    }
+    if(!is_object(config.shell)) {
+        log_error("C_YUI_SHELL: config.shell is missing or not an object");
+        return false;
+    }
+
+    let shell_cfg = config.shell;
+    if(shell_cfg.zones !== undefined && !is_object(shell_cfg.zones)) {
+        log_error("C_YUI_SHELL: config.shell.zones must be an object");
+        ok = false;
+    }
+    if(shell_cfg.stages !== undefined && !is_object(shell_cfg.stages)) {
+        log_error("C_YUI_SHELL: config.shell.stages must be an object");
+        ok = false;
+    }
+
+    let zones_cfg = is_object(shell_cfg.zones) ? shell_cfg.zones : {};
+    for(let zid in zones_cfg) {
+        if(ZONE_IDS.indexOf(zid) < 0) {
+            log_error(
+                `C_YUI_SHELL: unknown zone '${zid}' in config.shell.zones; ` +
+                `valid zones: ${ZONE_IDS.join(", ")}`
+            );
+            ok = false;
+        }
+    }
+
+    let stages_cfg = is_object(shell_cfg.stages) ? shell_cfg.stages : {};
+    for(let sname in stages_cfg) {
+        let st = stages_cfg[sname];
+        if(!is_object(st)) {
+            log_error(`C_YUI_SHELL: config.shell.stages.${sname} must be an object`);
+            ok = false;
+            continue;
+        }
+        let zone = st.zone || "center";
+        if(ZONE_IDS.indexOf(zone) < 0) {
+            log_error(
+                `C_YUI_SHELL: stage '${sname}' references unknown zone '${zone}'`
+            );
+            ok = false;
+        }
+    }
+
+    if(config.menu !== undefined && !is_object(config.menu)) {
+        log_error("C_YUI_SHELL: config.menu must be an object");
+        ok = false;
+    }
+    if(config.toolbar !== undefined && !is_array(config.toolbar)) {
+        log_error("C_YUI_SHELL: config.toolbar must be an array");
+        ok = false;
+    }
+
+    return ok;
+}
 
 /************************************************************
  *  Build the DOM: layers → base → zones
@@ -596,6 +691,16 @@ function route_to_hash(route)
 function navigate_to(gobj, route)
 {
     let priv = gobj_read_attr(gobj, "priv");
+
+    /*  Audit witness: publish the navigation intent FIRST, before any
+     *  validation or DOM work. This guarantees that the FSM trace and
+     *  any subscribed auditor see every requested route — including
+     *  rerouted submenu defaults and routes that ultimately fail. */
+    gobj_publish_event(gobj, "EV_NAVIGATION_REQUESTED", {
+        route: route,
+        from:  gobj_read_attr(gobj, "current_route") || ""
+    });
+
     if(empty_string(route)) {
         log_error("C_YUI_SHELL: navigate_to called with empty route");
         return;
@@ -643,7 +748,12 @@ function navigate_to(gobj, route)
         /*  lazy_destroy: drop previous on exit */
         let prev_entry = priv.item_index[prev_route];
         if(prev_entry && prev_entry.target && prev_entry.target.lifecycle === "lazy_destroy") {
-            try { gobj_stop(prev_gobj); gobj_destroy(prev_gobj); } catch(e) {}
+            try {
+                gobj_stop(prev_gobj);
+                gobj_destroy(prev_gobj);
+            } catch(e) {
+                log_warning(`C_YUI_SHELL: lazy_destroy of '${prev_route}' failed: ${e}`);
+            }
             delete stage.items[prev_route];
         }
     }
@@ -718,7 +828,11 @@ function build_view_gobj(gobj, entry, route, stage)
             `C_YUI_SHELL: gclass '${target.gclass}' does not expose $container; ` +
             `the view is unusable — check its mt_create`
         );
-        try { gobj_destroy(view); } catch(e) {}
+        try {
+            gobj_destroy(view);
+        } catch(e) {
+            log_warning(`C_YUI_SHELL: cleanup gobj_destroy failed for ${target.gclass}: ${e}`);
+        }
         return null;
     }
     stage.el.appendChild($view);
@@ -1177,10 +1291,16 @@ function create_gclass(gclass_name)
     ];
 
     const event_types = [
-        ["EV_NAV_CLICKED",   0],
-        ["EV_ROUTE_CHANGED", event_flag_t.EVF_OUTPUT_EVENT
-                            |event_flag_t.EVF_PUBLIC_EVENT
-                            |event_flag_t.EVF_NO_WARN_SUBS]
+        ["EV_NAV_CLICKED",          0],
+        /*  Audit witness: every navigation attempt publishes this BEFORE
+         *  any work is done, so the FSM trace records intent regardless
+         *  of whether the route resolves successfully. */
+        ["EV_NAVIGATION_REQUESTED", event_flag_t.EVF_OUTPUT_EVENT
+                                   |event_flag_t.EVF_PUBLIC_EVENT
+                                   |event_flag_t.EVF_NO_WARN_SUBS],
+        ["EV_ROUTE_CHANGED",        event_flag_t.EVF_OUTPUT_EVENT
+                                   |event_flag_t.EVF_PUBLIC_EVENT
+                                   |event_flag_t.EVF_NO_WARN_SUBS]
     ];
 
     __gclass__ = gclass_create(

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -111,7 +111,12 @@ function mt_create(gobj)
         navs:            [],
         item_index:      {},
         hash_handler:    null,
-        keydown_handler: null
+        keydown_handler: null,
+        /*  Escape priority chain: array of { layer, handler }.  Each
+         *  interactive overlay (drawer today, modal/popup tomorrow)
+         *  pushes its close handler when it opens and pops it when
+         *  it closes.  Escape calls the top handler only — LIFO. */
+        escape_stack:    []
     });
 
     build_ui(gobj);
@@ -157,11 +162,21 @@ function mt_start(gobj)
         window.addEventListener("hashchange", priv.hash_handler);
     }
 
-    /*  Global Escape to close any open drawer. */
+    /*  Global Escape: route to the top handler of the escape stack,
+     *  not to a hardcoded "close all drawers".  Modals and popups
+     *  push themselves on top of drawers, so Escape closes them
+     *  first; second Escape closes the drawer underneath; etc. */
     priv.keydown_handler = ev => {
-        if(ev.key === "Escape" || ev.keyCode === 27) {
-            close_all_drawers(gobj);
+        if(ev.key !== "Escape" && ev.keyCode !== 27) {
+            return;
         }
+        if(priv.escape_stack.length === 0) {
+            return;
+        }
+        let top = priv.escape_stack[priv.escape_stack.length - 1];
+        ev.preventDefault();
+        ev.stopPropagation();
+        top.handler();
     };
     window.addEventListener("keydown", priv.keydown_handler);
 
@@ -1111,38 +1126,84 @@ function release_focus_trap(gobj, $drawer)
     }
 }
 
+/************************************************************
+ *  Escape priority chain helpers — push/pop a {layer, handler}
+ *  record on `priv.escape_stack`.  Escape calls the top entry
+ *  only and consumes the event; LIFO ordering naturally matches
+ *  the z-index layering most apps use (drawer at the bottom,
+ *  modal on top, popup on top of that).
+ ************************************************************/
+function push_escape(gobj, layer, handler)
+{
+    let priv = gobj_read_attr(gobj, "priv");
+    if(!priv || !priv.escape_stack) {
+        return;
+    }
+    priv.escape_stack.push({ layer: layer, handler: handler });
+}
+
+function pop_escape(gobj, handler)
+{
+    let priv = gobj_read_attr(gobj, "priv");
+    if(!priv || !priv.escape_stack) {
+        return;
+    }
+    let idx = priv.escape_stack.findIndex(e => e.handler === handler);
+    if(idx >= 0) {
+        priv.escape_stack.splice(idx, 1);
+    }
+}
+
+/*  Per-drawer open/close.  The handler reference is parked on the
+ *  $drawer DOM element so any close path (Escape, backdrop click,
+ *  toolbar action, public yui_shell_close_drawer) ends up popping
+ *  the correct stack entry. */
+function open_drawer_one(gobj, $c)
+{
+    if($c.classList.contains("is-active")) {
+        return;
+    }
+    let close_fn = () => close_drawer_one(gobj, $c);
+    $c.__yui_close_handler__ = close_fn;
+    push_escape(gobj, "overlay", close_fn);
+    $c.classList.add("is-active");
+    activate_focus_trap(gobj, $c);
+}
+
+function close_drawer_one(gobj, $c)
+{
+    if(!$c.classList.contains("is-active")) {
+        return;
+    }
+    $c.classList.remove("is-active");
+    release_focus_trap(gobj, $c);
+    if($c.__yui_close_handler__) {
+        pop_escape(gobj, $c.__yui_close_handler__);
+        $c.__yui_close_handler__ = null;
+    }
+}
+
 function open_drawer(gobj, menu_id)
 {
     for(let $c of drawers(gobj, menu_id)) {
-        if($c.classList.contains("is-active")) {
-            continue;
-        }
-        $c.classList.add("is-active");
-        activate_focus_trap(gobj, $c);
+        open_drawer_one(gobj, $c);
     }
 }
 
 function close_drawer(gobj, menu_id)
 {
     for(let $c of drawers(gobj, menu_id)) {
-        if(!$c.classList.contains("is-active")) {
-            continue;
-        }
-        $c.classList.remove("is-active");
-        release_focus_trap(gobj, $c);
+        close_drawer_one(gobj, $c);
     }
 }
 
 function toggle_drawer(gobj, menu_id)
 {
     for(let $c of drawers(gobj, menu_id)) {
-        let was = $c.classList.contains("is-active");
-        $c.classList.toggle("is-active");
-        let now = $c.classList.contains("is-active");
-        if(now && !was) {
-            activate_focus_trap(gobj, $c);
-        } else if(!now && was) {
-            release_focus_trap(gobj, $c);
+        if($c.classList.contains("is-active")) {
+            close_drawer_one(gobj, $c);
+        } else {
+            open_drawer_one(gobj, $c);
         }
     }
 }
@@ -1161,11 +1222,7 @@ function close_all_drawers(gobj)
         if(!$c) {
             continue;
         }
-        if(!$c.classList.contains("is-active")) {
-            continue;
-        }
-        $c.classList.remove("is-active");
-        release_focus_trap(gobj, $c);
+        close_drawer_one(gobj, $c);
     }
 }
 
@@ -1268,6 +1325,19 @@ function ac_nav_clicked(gobj, event, kw, src)
     return 0;
 }
 
+/************************************************************
+ *  Drawer backdrop click on a C_YUI_NAV child: the nav publishes
+ *  this so the shell can close the drawer through the canonical
+ *  flow (DOM + focus-trap + escape-stack pop) instead of mutating
+ *  the DOM directly from the nav.
+ ************************************************************/
+function ac_drawer_close_requested(gobj, event, kw, src)
+{
+    let menu_id = (kw && kw.menu_id) || "";
+    close_drawer(gobj, menu_id);
+    return 0;
+}
+
 /***************************************************************
  *              FSM
  ***************************************************************/
@@ -1293,22 +1363,26 @@ function create_gclass(gclass_name)
             /*  Navigation requests flow through EV_NAV_CLICKED (emitted
              *  by child C_YUI_NAVs) and through the window.hashchange
              *  listener (see mt_start).  The shell is the sole router.  */
-            ["EV_NAV_CLICKED", ac_nav_clicked, null]
+            ["EV_NAV_CLICKED",            ac_nav_clicked,            null],
+            /*  Drawer backdrop close (from a C_YUI_NAV child whose
+             *  layout is "drawer"). */
+            ["EV_DRAWER_CLOSE_REQUESTED", ac_drawer_close_requested, null]
         ]]
     ];
 
     const event_types = [
-        ["EV_NAV_CLICKED",     0],
+        ["EV_NAV_CLICKED",            0],
+        ["EV_DRAWER_CLOSE_REQUESTED", 0],
         /*  Audit witness: every navigation attempt publishes this BEFORE
          *  any work is done, so the FSM trace records intent regardless
          *  of whether the route resolves successfully.  Pairs with
          *  EV_ROUTE_CHANGED (the corresponding fact event). */
-        ["EV_ROUTE_REQUESTED", event_flag_t.EVF_OUTPUT_EVENT
-                              |event_flag_t.EVF_PUBLIC_EVENT
-                              |event_flag_t.EVF_NO_WARN_SUBS],
-        ["EV_ROUTE_CHANGED",   event_flag_t.EVF_OUTPUT_EVENT
-                              |event_flag_t.EVF_PUBLIC_EVENT
-                              |event_flag_t.EVF_NO_WARN_SUBS]
+        ["EV_ROUTE_REQUESTED",        event_flag_t.EVF_OUTPUT_EVENT
+                                     |event_flag_t.EVF_PUBLIC_EVENT
+                                     |event_flag_t.EVF_NO_WARN_SUBS],
+        ["EV_ROUTE_CHANGED",          event_flag_t.EVF_OUTPUT_EVENT
+                                     |event_flag_t.EVF_PUBLIC_EVENT
+                                     |event_flag_t.EVF_NO_WARN_SUBS]
     ];
 
     __gclass__ = gclass_create(
@@ -1355,6 +1429,28 @@ function yui_shell_open_drawer(shell_gobj, menu_id)    { open_drawer(shell_gobj,
 function yui_shell_close_drawer(shell_gobj, menu_id)   { close_drawer(shell_gobj, menu_id);  }
 function yui_shell_toggle_drawer(shell_gobj, menu_id)  { toggle_drawer(shell_gobj, menu_id); }
 
+/*  Escape priority chain — public API used by overlays that the
+ *  shell does not own (modals from #4, future popups, custom
+ *  app-level overlays).  Drawer integration is built in.
+ *
+ *      let close_fn = () => my_modal.close();
+ *      yui_shell_push_escape(shell, "modal", close_fn);
+ *      // ... when the modal closes by any path, also call:
+ *      yui_shell_pop_escape(shell, close_fn);
+ *
+ *  `layer` is a free-form tag (e.g. "modal", "popup", "overlay").
+ *  Today it is informational; the LIFO ordering of the stack is
+ *  what determines Escape priority — and naturally matches the
+ *  z-index layering most apps use (drawer < popup < modal). */
+function yui_shell_push_escape(shell_gobj, layer, handler)
+{
+    push_escape(shell_gobj, layer, handler);
+}
+function yui_shell_pop_escape(shell_gobj, handler)
+{
+    pop_escape(shell_gobj, handler);
+}
+
 /*  Note: there is no shell-level language switch helper.  Every
  *  translatable text node rendered by the shell and its navs is
  *  tagged with `data-i18n` (the canonical English key).  Apps swap
@@ -1368,5 +1464,7 @@ export {
     yui_shell_navigate,
     yui_shell_open_drawer,
     yui_shell_close_drawer,
-    yui_shell_toggle_drawer
+    yui_shell_toggle_drawer,
+    yui_shell_push_escape,
+    yui_shell_pop_escape
 };

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -908,12 +908,17 @@ function navigate_to(gobj, route)
         }
     }
 
-    /*  Broadcast */
+    /*  Broadcast.  `menu_id` carries the owning primary menu so
+     *  primary navs can short-circuit when the route belongs to a
+     *  different menu — without it, two primary-style menus that
+     *  share an item id (legitimate per TODO #5) cross-highlight
+     *  each other. */
     gobj_publish_event(gobj, "EV_ROUTE_CHANGED", {
         route: route,
         item: entry.item,
         parent_item: entry.parent_item,
-        stage: stage_name
+        stage: stage_name,
+        menu_id: entry.menu_id || ""
     });
 }
 

--- a/kernel/js/lib-yui/src/shell_focus_trap.js
+++ b/kernel/js/lib-yui/src/shell_focus_trap.js
@@ -1,0 +1,101 @@
+/***********************************************************************
+ *          shell_focus_trap.js
+ *
+ *      Generic focus-trap helper used by C_YUI_SHELL for drawers,
+ *      modals and any other overlay that must capture keyboard
+ *      navigation while open.
+ *
+ *      Usage:
+ *          let release = activate_focus_trap_on($panel);
+ *          // ... when the overlay closes:
+ *          release();
+ *
+ *      The trap:
+ *          - captures Tab / Shift+Tab so focus cycles inside $panel,
+ *          - moves focus to the first focusable child on activate,
+ *          - restores focus to whatever element had it before
+ *            activation when release() runs.
+ *
+ *      Pure module — no gobj / Yuneta dependencies.  The optional
+ *      second argument lets callers inject a mock document object
+ *      for unit tests.
+ *
+ *          Copyright (c) 2026, ArtGins.
+ *          All Rights Reserved.
+ ***********************************************************************/
+
+/*  Selector matching the elements typically considered focusable.
+ *  Kept conservative: items that are explicitly removed from the tab
+ *  order (`tabindex="-1"`) are excluded; everything else is in. */
+export const FOCUSABLE_SELECTOR =
+    "a[href], button:not([disabled]), input:not([disabled])," +
+    " select:not([disabled]), textarea:not([disabled])," +
+    " [tabindex]:not([tabindex=\"-1\"])";
+
+
+/***************************************************************
+ *  Activate the focus-trap on $panel.
+ *
+ *  Returns a `release` function that must be called to tear the
+ *  trap down when the overlay closes.  Calling release() multiple
+ *  times is safe (becomes a no-op after the first call).
+ *
+ *  `doc` defaults to globalThis.document; pass a stub for tests.
+ ***************************************************************/
+export function activate_focus_trap_on($panel, doc)
+{
+    if(!doc) {
+        doc = globalThis.document;
+    }
+    if(!$panel || !doc) {
+        return function noop() {};
+    }
+
+    let saved = doc.activeElement || null;
+    let released = false;
+
+    let trap = function(ev) {
+        if(ev.key !== "Tab" && ev.keyCode !== 9) {
+            return;
+        }
+        let nodes = $panel.querySelectorAll(FOCUSABLE_SELECTOR);
+        if(nodes.length === 0) {
+            return;
+        }
+        let first = nodes[0];
+        let last  = nodes[nodes.length - 1];
+        let inside = $panel.contains(doc.activeElement);
+
+        if(ev.shiftKey) {
+            if(!inside || doc.activeElement === first) {
+                last.focus();
+                ev.preventDefault();
+            }
+        } else {
+            if(!inside || doc.activeElement === last) {
+                first.focus();
+                ev.preventDefault();
+            }
+        }
+    };
+    doc.addEventListener("keydown", trap, true);
+
+    /*  Move focus to the first focusable child of the panel. */
+    let firstFocusable = $panel.querySelector(FOCUSABLE_SELECTOR);
+    if(firstFocusable && typeof firstFocusable.focus === "function") {
+        firstFocusable.focus();
+    }
+
+    return function release_focus_trap() {
+        if(released) {
+            return;
+        }
+        released = true;
+        doc.removeEventListener("keydown", trap, true);
+        if(saved && typeof saved.focus === "function" &&
+           (!doc.body || !doc.body.contains || doc.body.contains(saved)))
+        {
+            saved.focus();
+        }
+    };
+}

--- a/kernel/js/lib-yui/src/shell_focus_trap.js
+++ b/kernel/js/lib-yui/src/shell_focus_trap.js
@@ -33,6 +33,16 @@ export const FOCUSABLE_SELECTOR =
     " [tabindex]:not([tabindex=\"-1\"])";
 
 
+/*  Module-local LIFO stack of active traps.  Multiple overlays can
+ *  be open simultaneously (modal over drawer, popup over modal, …)
+ *  and each registers its own document-level keydown listener.
+ *  Without arbitration every Tab fires every listener, which forces
+ *  focus to the deepest trap's first/last on every press and makes
+ *  middle elements unreachable.  We keep one stack and only run the
+ *  topmost trap; the rest short-circuit. */
+const __trap_stack__ = [];
+
+
 /***************************************************************
  *  Activate the focus-trap on $panel.
  *
@@ -58,6 +68,13 @@ export function activate_focus_trap_on($panel, doc)
         if(ev.key !== "Tab" && ev.keyCode !== 9) {
             return;
         }
+        /*  LIFO arbitration: only the topmost active trap acts.
+         *  Earlier-registered listeners fire too (capture phase),
+         *  but they short-circuit unless they own the top of the
+         *  stack. */
+        if(__trap_stack__[__trap_stack__.length - 1] !== trap) {
+            return;
+        }
         let nodes = $panel.querySelectorAll(FOCUSABLE_SELECTOR);
         if(nodes.length === 0) {
             return;
@@ -79,6 +96,7 @@ export function activate_focus_trap_on($panel, doc)
         }
     };
     doc.addEventListener("keydown", trap, true);
+    __trap_stack__.push(trap);
 
     /*  Move focus to the first focusable child of the panel. */
     let firstFocusable = $panel.querySelector(FOCUSABLE_SELECTOR);
@@ -92,6 +110,10 @@ export function activate_focus_trap_on($panel, doc)
         }
         released = true;
         doc.removeEventListener("keydown", trap, true);
+        let idx = __trap_stack__.indexOf(trap);
+        if(idx >= 0) {
+            __trap_stack__.splice(idx, 1);
+        }
         if(saved && typeof saved.focus === "function" &&
            (!doc.body || !doc.body.contains || doc.body.contains(saved)))
         {

--- a/kernel/js/lib-yui/src/shell_modals.js
+++ b/kernel/js/lib-yui/src/shell_modals.js
@@ -29,6 +29,8 @@
 import {
     gobj_read_attr,
     createElement2,
+    refresh_language,
+    empty_string,
     log_warning,
 } from "@yuneta/gobj-js";
 
@@ -59,6 +61,26 @@ function modal_layer(shell)
 
 
 /***************************************************************
+ *  i18n bridge:
+ *      - `text` is rendered as the canonical English key.
+ *      - The hosting element is tagged with `data-i18n="<key>"`,
+ *        so a later `refresh_language(shell.$container, t)` call
+ *        retranslates the modal even if it was created BEFORE the
+ *        language was switched.
+ *      - If `opts.t` is a function, the helper translates the
+ *        node right after creating it — so a modal opened AFTER
+ *        the user has already toggled to ES renders in ES on the
+ *        first frame, not the canonical English key.
+ ***************************************************************/
+function maybe_apply_translator($node, opts)
+{
+    if(opts && typeof opts.t === "function") {
+        refresh_language($node, opts.t);
+    }
+}
+
+
+/***************************************************************
  *              Notifications (Bulma .notification)
  *
  *      Non-blocking, auto-dismiss after `opts.timeout` ms (default
@@ -73,16 +95,20 @@ function show_notification(shell, kind, message, opts)
         return { close: () => {} };
     }
 
+    let p_attrs = (typeof message === "string")
+        ? {i18n: message}
+        : {};
     let $note = createElement2(
         ["div", {class: `notification yui-notification is-${kind} is-light`,
                  role: kind === "danger" ? "alert" : "status"},
             [
                 ["button", {class: "delete", "aria-label": "close"}],
-                ["p", {}, message]
+                ["p", p_attrs, message]
             ]
         ]
     );
     $layer.appendChild($note);
+    maybe_apply_translator($note, opts);
 
     let timeout_id = null;
     let closed = false;
@@ -147,7 +173,7 @@ export function yui_shell_show_modal(shell, content, opts)
     }
 
     let inner = (typeof content === "string")
-        ? ["div", {class: "box"}, [["p", {}, content]]]
+        ? ["div", {class: "box"}, [["p", {i18n: content}, content]]]
         : null;
 
     let $modal = createElement2(
@@ -169,6 +195,8 @@ export function yui_shell_show_modal(shell, content, opts)
         let $content = $modal.querySelector(".modal-content");
         $content.appendChild(content);
     }
+
+    maybe_apply_translator($modal, opts);
 
     let closed = false;
     let close_fn = null;
@@ -227,8 +255,12 @@ function build_dialog(shell, message, buttons, opts)
     let dismiss_value = buttons[buttons.length - 1].value;
 
     let $body_children = (typeof message === "string")
-        ? [["p", {}, message]]
+        ? [["p", {i18n: message}, message]]
         : [message];
+
+    let title_attrs = !empty_string(title)
+        ? {class: "modal-card-title", i18n: title}
+        : {class: "modal-card-title"};
 
     let $footer_children = buttons.map(b => {
         let cls = "button";
@@ -237,9 +269,12 @@ function build_dialog(shell, message, buttons, opts)
         } else if(b.kind === "danger") {
             cls += " is-danger";
         }
-        return ["button", {class: cls, type: "button",
-                           "data-modal-button-value": b.value},
-                b.label];
+        let btn_attrs = {class: cls, type: "button",
+                         "data-modal-button-value": b.value};
+        if(typeof b.label === "string") {
+            btn_attrs.i18n = b.label;
+        }
+        return ["button", btn_attrs, b.label];
     });
 
     let $modal = createElement2(
@@ -251,7 +286,7 @@ function build_dialog(shell, message, buttons, opts)
                     [
                         ["header", {class: "modal-card-head"},
                             [
-                                ["p", {class: "modal-card-title"}, title],
+                                ["p", title_attrs, title],
                                 ["button", {class: "delete",
                                             "aria-label": "close"}]
                             ]
@@ -264,6 +299,7 @@ function build_dialog(shell, message, buttons, opts)
         ]
     );
     $layer.appendChild($modal);
+    maybe_apply_translator($modal, opts);
 
     return new Promise(resolve => {
         let resolved = false;

--- a/kernel/js/lib-yui/src/shell_modals.js
+++ b/kernel/js/lib-yui/src/shell_modals.js
@@ -1,0 +1,344 @@
+/***********************************************************************
+ *          shell_modals.js
+ *
+ *      Modal / notification API on top of the layers C_YUI_SHELL
+ *      already creates (`priv.layers.notification`,
+ *      `priv.layers.modal`).  Naming convention:
+ *
+ *          yui_shell_show_*     — non-blocking notifications/modal
+ *          yui_shell_confirm_*  — blocking dialog, returns Promise
+ *
+ *      Bulma `.notification` / `.modal-card` markup is reused
+ *      verbatim so apps importing Bulma get the visual styling for
+ *      free.
+ *
+ *      Every blocking dialog and every modal pushes a close handler
+ *      onto the shell's Escape priority chain (see
+ *      yui_shell_push_escape / yui_shell_pop_escape) so Escape
+ *      closes the topmost overlay only.
+ *
+ *      The legacy display_* / get_yes* helpers in c_yui_main.js are
+ *      NOT changed — apps that ride on the legacy shell keep using
+ *      them (see SHELL.md §10 drift policy).
+ *
+ *          Copyright (c) 2026, ArtGins.
+ *          All Rights Reserved.
+ ***********************************************************************/
+/* global document */
+
+import {
+    gobj_read_attr,
+    createElement2,
+    log_warning,
+} from "@yuneta/gobj-js";
+
+import {
+    activate_focus_trap_on,
+} from "./shell_focus_trap.js";
+
+import {
+    yui_shell_push_escape,
+    yui_shell_pop_escape,
+} from "./c_yui_shell.js";
+
+
+/***************************************************************
+ *              Layer accessors
+ ***************************************************************/
+function notification_layer(shell)
+{
+    let priv = gobj_read_attr(shell, "priv");
+    return priv && priv.layers && priv.layers.notification;
+}
+
+function modal_layer(shell)
+{
+    let priv = gobj_read_attr(shell, "priv");
+    return priv && priv.layers && priv.layers.modal;
+}
+
+
+/***************************************************************
+ *              Notifications (Bulma .notification)
+ *
+ *      Non-blocking, auto-dismiss after `opts.timeout` ms (default
+ *      5000).  `opts.timeout = 0` disables auto-dismiss.
+ *      Returns `{ close() }` so callers can dismiss programmatically.
+ ***************************************************************/
+function show_notification(shell, kind, message, opts)
+{
+    let $layer = notification_layer(shell);
+    if(!$layer) {
+        log_warning("yui_shell_show_*: shell has no notification layer");
+        return { close: () => {} };
+    }
+
+    let $note = createElement2(
+        ["div", {class: `notification yui-notification is-${kind} is-light`,
+                 role: kind === "danger" ? "alert" : "status"},
+            [
+                ["button", {class: "delete", "aria-label": "close"}],
+                ["p", {}, message]
+            ]
+        ]
+    );
+    $layer.appendChild($note);
+
+    let timeout_id = null;
+    let closed = false;
+
+    let close = function() {
+        if(closed) {
+            return;
+        }
+        closed = true;
+        if(timeout_id) {
+            clearTimeout(timeout_id);
+            timeout_id = null;
+        }
+        if($note.parentNode) {
+            $note.parentNode.removeChild($note);
+        }
+    };
+
+    let $del = $note.querySelector(".delete");
+    if($del) {
+        $del.addEventListener("click", close);
+    }
+
+    let timeout = (opts && opts.timeout != null) ? opts.timeout : 5000;
+    if(timeout > 0) {
+        timeout_id = setTimeout(close, timeout);
+    }
+
+    return { close };
+}
+
+
+export function yui_shell_show_info(shell, message, opts)
+{
+    return show_notification(shell, "info", message, opts);
+}
+export function yui_shell_show_warning(shell, message, opts)
+{
+    return show_notification(shell, "warning", message, opts);
+}
+export function yui_shell_show_error(shell, message, opts)
+{
+    return show_notification(shell, "danger", message, opts);
+}
+
+
+/***************************************************************
+ *              Modal (Bulma .modal — non-blocking)
+ *
+ *      Drops a Bulma `.modal-content` overlay into the modal layer.
+ *      `content` may be a string (rendered inside a Bulma .box) or
+ *      an HTMLElement (rendered as-is).  Returns `{ close() }`.
+ *      The caller decides when to dismiss; click on background,
+ *      the `.modal-close` button, or `Escape` also close it.
+ ***************************************************************/
+export function yui_shell_show_modal(shell, content, opts)
+{
+    let $layer = modal_layer(shell);
+    if(!$layer) {
+        log_warning("yui_shell_show_modal: shell has no modal layer");
+        return { close: () => {} };
+    }
+
+    let inner = (typeof content === "string")
+        ? ["div", {class: "box"}, [["p", {}, content]]]
+        : null;
+
+    let $modal = createElement2(
+        ["div", {class: "modal yui-modal is-active",
+                 role: "dialog", "aria-modal": "true"},
+            [
+                ["div", {class: "modal-background"}],
+                ["div", {class: "modal-content"},
+                    inner ? [inner] : []
+                ],
+                ["button", {class: "modal-close is-large",
+                            "aria-label": "close"}]
+            ]
+        ]
+    );
+    $layer.appendChild($modal);
+
+    if(!inner && content && typeof content.appendChild !== "undefined") {
+        let $content = $modal.querySelector(".modal-content");
+        $content.appendChild(content);
+    }
+
+    let closed = false;
+    let close_fn = null;
+    let release_focus = null;
+
+    let close = function() {
+        if(closed) {
+            return;
+        }
+        closed = true;
+        if(release_focus) {
+            release_focus();
+            release_focus = null;
+        }
+        if(close_fn) {
+            yui_shell_pop_escape(shell, close_fn);
+            close_fn = null;
+        }
+        if($modal.parentNode) {
+            $modal.parentNode.removeChild($modal);
+        }
+    };
+    close_fn = close;
+
+    yui_shell_push_escape(shell, "modal", close);
+    release_focus = activate_focus_trap_on(
+        $modal.querySelector(".modal-content")
+    );
+
+    if((opts == null || opts.dismiss_on_background !== false)) {
+        $modal.querySelector(".modal-background").addEventListener("click", close);
+    }
+    $modal.querySelector(".modal-close").addEventListener("click", close);
+
+    return { close };
+}
+
+
+/***************************************************************
+ *              Blocking dialogs (Bulma .modal-card)
+ *
+ *      build_dialog returns a Promise that resolves with the
+ *      clicked button's `value`.  Escape, the close button and
+ *      the dismiss action all resolve with the LAST button's value
+ *      (cancel/no/ok by convention — the safe-default action).
+ ***************************************************************/
+function build_dialog(shell, message, buttons, opts)
+{
+    let $layer = modal_layer(shell);
+    if(!$layer) {
+        log_warning("yui_shell_confirm_*: shell has no modal layer");
+        return Promise.resolve(buttons[buttons.length - 1].value);
+    }
+
+    let title = (opts && opts.title) || "";
+    let dismiss_value = buttons[buttons.length - 1].value;
+
+    let $body_children = (typeof message === "string")
+        ? [["p", {}, message]]
+        : [message];
+
+    let $footer_children = buttons.map(b => {
+        let cls = "button";
+        if(b.kind === "primary") {
+            cls += " is-link";
+        } else if(b.kind === "danger") {
+            cls += " is-danger";
+        }
+        return ["button", {class: cls, type: "button",
+                           "data-modal-button-value": b.value},
+                b.label];
+    });
+
+    let $modal = createElement2(
+        ["div", {class: "modal yui-modal yui-confirm is-active",
+                 role: "dialog", "aria-modal": "true"},
+            [
+                ["div", {class: "modal-background"}],
+                ["div", {class: "modal-card"},
+                    [
+                        ["header", {class: "modal-card-head"},
+                            [
+                                ["p", {class: "modal-card-title"}, title],
+                                ["button", {class: "delete",
+                                            "aria-label": "close"}]
+                            ]
+                        ],
+                        ["section", {class: "modal-card-body"}, $body_children],
+                        ["footer", {class: "modal-card-foot"}, $footer_children]
+                    ]
+                ]
+            ]
+        ]
+    );
+    $layer.appendChild($modal);
+
+    return new Promise(resolve => {
+        let resolved = false;
+        let close_fn = null;
+        let release_focus = null;
+
+        let close = function(value) {
+            if(resolved) {
+                return;
+            }
+            resolved = true;
+            if(release_focus) {
+                release_focus();
+                release_focus = null;
+            }
+            if(close_fn) {
+                yui_shell_pop_escape(shell, close_fn);
+                close_fn = null;
+            }
+            if($modal.parentNode) {
+                $modal.parentNode.removeChild($modal);
+            }
+            resolve(value);
+        };
+        close_fn = () => close(dismiss_value);
+
+        yui_shell_push_escape(shell, "modal", close_fn);
+        release_focus = activate_focus_trap_on(
+            $modal.querySelector(".modal-card")
+        );
+
+        $modal.querySelector(".modal-background").addEventListener(
+            "click", () => close(dismiss_value)
+        );
+        $modal.querySelector(".modal-card-head .delete").addEventListener(
+            "click", () => close(dismiss_value)
+        );
+        let footer_buttons = $modal.querySelectorAll(
+            ".modal-card-foot button"
+        );
+        footer_buttons.forEach($btn => {
+            $btn.addEventListener("click", () => {
+                close($btn.getAttribute("data-modal-button-value"));
+            });
+        });
+    });
+}
+
+
+export function yui_shell_confirm_ok(shell, message, opts)
+{
+    let label = (opts && opts.ok_label) || "OK";
+    return build_dialog(shell, message, [
+        {label: label, value: "ok", kind: "primary"}
+    ], opts).then(() => undefined);
+}
+
+export function yui_shell_confirm_yesno(shell, message, opts)
+{
+    let yes_label = (opts && opts.yes_label) || "Yes";
+    let no_label  = (opts && opts.no_label)  || "No";
+    return build_dialog(shell, message, [
+        {label: yes_label, value: "yes", kind: "primary"},
+        {label: no_label,  value: "no"}
+    ], opts).then(v => v === "yes");
+}
+
+export function yui_shell_confirm_yesnocancel(shell, message, opts)
+{
+    let yes_label    = (opts && opts.yes_label)    || "Yes";
+    let no_label     = (opts && opts.no_label)     || "No";
+    let cancel_label = (opts && opts.cancel_label) || "Cancel";
+    return build_dialog(shell, message, [
+        {label: yes_label,    value: "yes", kind: "primary"},
+        {label: no_label,     value: "no"},
+        {label: cancel_label, value: "cancel"}
+    ], opts);
+}

--- a/kernel/js/lib-yui/src/shell_modals.js
+++ b/kernel/js/lib-yui/src/shell_modals.js
@@ -222,9 +222,12 @@ export function yui_shell_show_modal(shell, content, opts)
     close_fn = close;
 
     yui_shell_push_escape(shell, "modal", close);
-    release_focus = activate_focus_trap_on(
-        $modal.querySelector(".modal-content")
-    );
+    /*  Trap on $modal (not on .modal-content) so the .modal-close
+     *  button — rendered as a SIBLING of .modal-content — is
+     *  reachable via Tab.  Without this, Tab/Shift+Tab can only
+     *  cycle among focusables that the caller put inside
+     *  .modal-content; the X button can only be clicked. */
+    release_focus = activate_focus_trap_on($modal);
 
     if((opts == null || opts.dismiss_on_background !== false)) {
         $modal.querySelector(".modal-background").addEventListener("click", close);

--- a/kernel/js/lib-yui/test-app/README.md
+++ b/kernel/js/lib-yui/test-app/README.md
@@ -3,7 +3,7 @@
 Standalone harness to exercise `C_YUI_SHELL` + `C_YUI_NAV` in isolation
 (no backend, no auth, no treedb).
 
-## Run
+## Run (interactive)
 
 ```bash
 cd kernel/js/lib-yui/test-app
@@ -12,6 +12,26 @@ npm run dev
 ```
 
 Then open http://localhost:5180 (Vite auto-opens it).
+
+## Run (Playwright smoke — automated)
+
+The library ships an end-to-end suite in
+`kernel/js/lib-yui/tests-e2e/` driven by Playwright. It boots the
+test-app via `vite preview` against the built bundle (port 5181) and
+runs against chromium and firefox.
+
+```bash
+cd kernel/js/lib-yui
+npm install                              # installs @playwright/test
+npx playwright install chromium firefox  # one-off browser download
+npm run test:e2e                         # headless, both browsers
+npm run test:e2e:ui                      # Playwright UI mode (debug)
+```
+
+`npm run test:all` runs the parser unit tests and the e2e suite back
+to back. CI runs the same combination via
+`.github/workflows/lib-yui.yml` on every PR touching
+`kernel/js/lib-yui/**`.
 
 ## Presets
 

--- a/kernel/js/lib-yui/test-app/README.md
+++ b/kernel/js/lib-yui/test-app/README.md
@@ -22,11 +22,18 @@ runs against chromium and firefox.
 
 ```bash
 cd kernel/js/lib-yui
-npm install                              # installs @playwright/test
-npx playwright install chromium firefox  # one-off browser download
-npm run test:e2e                         # headless, both browsers
-npm run test:e2e:ui                      # Playwright UI mode (debug)
+npm install                # installs @playwright/test
+./install-e2e-deps.sh      # downloads browser binaries + apt deps for webkit
+npm run test:e2e           # headless, all three browsers (chromium/firefox/webkit)
+npm run test:e2e:ui        # Playwright UI mode (debug)
 ```
+
+> **Linux only**: `install-e2e-deps.sh` runs `sudo npx playwright
+> install-deps webkit` once to install the system libraries WebKit
+> links against (`libgstreamer-plugins-bad1.0-0`, `libavif16`, …).
+> Chromium and Firefox bundle their own deps and need no apt
+> packages.  CI does the same step via `npx playwright install
+> --with-deps chromium firefox webkit` (no manual sudo there).
 
 `npm run test:all` runs the parser unit tests and the e2e suite back
 to back. CI runs the same combination via

--- a/kernel/js/lib-yui/test-app/src/app_config.json
+++ b/kernel/js/lib-yui/test-app/src/app_config.json
@@ -43,6 +43,22 @@
                 "action": { "type": "navigate", "route": "/help" }
             },
             {
+                "id": "say-hello",
+                "icon": "icon-bell",
+                "name": "Hello",
+                "align": "end",
+                "aria_label": "Show a hello toast",
+                "action": { "type": "event", "event": "EV_SHOW_HELLO" }
+            },
+            {
+                "id": "ask-question",
+                "icon": "icon-question",
+                "name": "Ask",
+                "align": "end",
+                "aria_label": "Open a yes/no dialog",
+                "action": { "type": "event", "event": "EV_ASK_QUESTION" }
+            },
+            {
                 "id": "lang",
                 "icon": "icon-translate",
                 "name": "ES/EN",

--- a/kernel/js/lib-yui/test-app/src/app_config_invalid.json
+++ b/kernel/js/lib-yui/test-app/src/app_config_invalid.json
@@ -1,0 +1,14 @@
+{
+    "_comment": "Deliberately invalid config used by tests-e2e/validator.spec.mjs to exercise validate_config().  Two breakage modes are encoded: an unknown zone id ('centre' instead of 'center') and an invalid host ('window.foo').",
+
+    "shell": {
+        "zones": {
+            "top":     { "host": "toolbar",      "show_on": ">=tablet" },
+            "centre":  { "host": "stage.main" },
+            "bottom":  { "host": "window.foo" }
+        },
+        "stages": {
+            "main": { "zone": "centre" }
+        }
+    }
+}

--- a/kernel/js/lib-yui/test-app/src/app_config_multimenu.json
+++ b/kernel/js/lib-yui/test-app/src/app_config_multimenu.json
@@ -1,0 +1,80 @@
+{
+    "_comment": "Regression preset for TODO #5: two primary-style menus mounted side-by-side. Each declares submenu items with their own render block; the shell auto-instantiates a level-2 nav per (menu_id, item.id) pair, scoped via secondary.<menu_id>.<item.id> so the two trees can never collide.",
+
+    "shell": {
+        "breakpoints": "bulma",
+
+        "zones": {
+            "top":        { "host": "toolbar",       "show_on": ">=tablet" },
+            "left":       { "host": "menu.primary",  "show_on": ">=desktop" },
+            "right":      { "host": "menu.admin",    "show_on": ">=desktop" },
+            "top-sub":    {},
+            "bottom":     { "host": "menu.primary",  "show_on": "<desktop"  },
+            "bottom-sub": { "host": "menu.admin",    "show_on": "<desktop"  },
+            "center":     { "host": "stage.main" }
+        },
+
+        "stages": {
+            "main": { "zone": "center", "default_route": "/dash/ov" }
+        }
+    },
+
+    "toolbar": {
+        "zone": "top",
+        "items": [
+            { "id": "home", "icon": "icon-home", "name": "Home",
+              "action": { "type": "navigate", "route": "/dash/ov" } }
+        ]
+    },
+
+    "menu": {
+        "primary": {
+            "render": {
+                "left":   { "layout": "vertical", "icon_pos": "left" },
+                "bottom": { "layout": "icon-bar", "icon_pos": "top" }
+            },
+            "items": [
+                {
+                    "id": "dash", "name": "Dashboard", "icon": "icon-dash",
+                    "route": "/dash",
+                    "submenu": {
+                        "render": { "top-sub": "tabs" },
+                        "items": [
+                            { "id": "ov",      "name": "Overview", "route": "/dash/ov",
+                              "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                                          "kw": { "title": "Overview", "color": "#2A9D8F" } } },
+                            { "id": "alerts",  "name": "Alerts",   "route": "/dash/alerts",
+                              "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                                          "kw": { "title": "Alerts", "color": "#E9C46A" } } }
+                        ]
+                    }
+                }
+            ]
+        },
+
+        "admin": {
+            "render": {
+                "right":      { "layout": "vertical", "icon_pos": "left" },
+                "bottom-sub": { "layout": "icon-bar", "icon_pos": "top" }
+            },
+            "items": [
+                {
+                    "id": "dash", "name": "Admin: Dashboard", "icon": "icon-gear",
+                    "route": "/admin/dash",
+                    "submenu": {
+                        "_comment": "Same item id ('dash') as menu.primary above — the regression test verifies the two secondary navs do not collide.",
+                        "render": { "top-sub": "tabs" },
+                        "items": [
+                            { "id": "users",   "name": "Users",   "route": "/admin/dash/users",
+                              "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                                          "kw": { "title": "Admin / Users", "color": "#6D597A" } } },
+                            { "id": "billing", "name": "Billing", "route": "/admin/dash/billing",
+                              "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                                          "kw": { "title": "Admin / Billing", "color": "#264653" } } }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/kernel/js/lib-yui/test-app/src/c_test_lang.js
+++ b/kernel/js/lib-yui/test-app/src/c_test_lang.js
@@ -65,6 +65,25 @@ const DICT_ES = {
     "Open quick menu":   "Abrir menú rápido",
     "ES/EN":             "EN/ES",
     "App toolbar":       "Barra de herramientas",
+
+    /*  Strings that show up inside modals/toasts the test-app fires
+     *  from C_TEST_LANG.ac_show_hello / ac_ask_question.  Helpers are
+     *  passed `opts.t` so they render in the active language at
+     *  open time AND still respond to refresh_language afterwards. */
+    "Hello from the shell!":             "¡Hola desde el shell!",
+    "A small smoke check":               "Una pequeña comprobación",
+    "Is the new shell working as expected?":
+        "¿Funciona el nuevo shell como esperabas?",
+    "Glad to hear it!":                  "¡Me alegro!",
+    "Noted — check the console.":        "Tomo nota — revisa la consola.",
+
+    /*  Default modal button labels (Yes/No/Cancel/OK).  The shell
+     *  helpers render these literally; refresh_language picks them
+     *  up via `data-i18n="<canonical key>"`. */
+    "Yes":    "Sí",
+    "No":     "No",
+    "Cancel": "Cancelar",
+    "OK":     "Aceptar"
 };
 
 
@@ -203,6 +222,17 @@ function ac_toggle_language(gobj, event, kw, src)
     return 0;
 }
 
+/*  Build a translator for the active language.  Used both by
+ *  ac_toggle_language (to refresh the whole DOM) and by the
+ *  show_hello / ask_question handlers (to render their modals in
+ *  the current language at open time, not the canonical English
+ *  key). */
+function current_translator(gobj)
+{
+    let is_es = gobj_read_attr(gobj, "is_es");
+    return make_translator(is_es ? DICT_ES : DICT_EN);
+}
+
 /***************************************************************
  *  Toolbar fired EV_SHOW_HELLO — paints a Bulma .notification
  *  via the shell helper, no view code involved.  Smoke test for
@@ -214,7 +244,9 @@ function ac_show_hello(gobj, event, kw, src)
     if(!shell) {
         return 0;
     }
-    yui_shell_show_info(shell, "Hello from the shell!");
+    yui_shell_show_info(shell, "Hello from the shell!", {
+        t: current_translator(gobj)
+    });
     return 0;
 }
 
@@ -229,13 +261,14 @@ function ac_ask_question(gobj, event, kw, src)
     if(!shell) {
         return 0;
     }
+    let t = current_translator(gobj);
     yui_shell_confirm_yesno(
         shell,
         "Is the new shell working as expected?",
-        { title: "A small smoke check" }
+        { title: "A small smoke check", t: t }
     ).then(answer => {
         let msg = answer ? "Glad to hear it!" : "Noted — check the console.";
-        yui_shell_show_info(shell, msg);
+        yui_shell_show_info(shell, msg, { t: current_translator(gobj) });
     });
     return 0;
 }

--- a/kernel/js/lib-yui/test-app/src/c_test_lang.js
+++ b/kernel/js/lib-yui/test-app/src/c_test_lang.js
@@ -26,6 +26,11 @@ import {
     refresh_language,
 } from "@yuneta/gobj-js";
 
+import {
+    yui_shell_show_info,
+    yui_shell_confirm_yesno,
+} from "@yuneta/lib-yui";
+
 
 /***************************************************************
  *              Constants
@@ -116,8 +121,10 @@ function mt_start(gobj)
      *  event_types table. */
     try {
         gobj_subscribe_event(shell, "EV_TOGGLE_LANGUAGE", {}, gobj);
+        gobj_subscribe_event(shell, "EV_SHOW_HELLO",      {}, gobj);
+        gobj_subscribe_event(shell, "EV_ASK_QUESTION",    {}, gobj);
     } catch(e) {
-        log_error(`C_TEST_LANG: subscribe to shell EV_TOGGLE_LANGUAGE failed: ${e}`);
+        log_error(`C_TEST_LANG: subscribe to shell events failed: ${e}`);
     }
 }
 
@@ -194,6 +201,43 @@ function ac_toggle_language(gobj, event, kw, src)
     return 0;
 }
 
+/***************************************************************
+ *  Toolbar fired EV_SHOW_HELLO — paints a Bulma .notification
+ *  via the shell helper, no view code involved.  Smoke test for
+ *  yui_shell_show_info.
+ ***************************************************************/
+function ac_show_hello(gobj, event, kw, src)
+{
+    let shell = gobj_read_pointer_attr(gobj, "shell");
+    if(!shell) {
+        return 0;
+    }
+    yui_shell_show_info(shell, "Hello from the shell!");
+    return 0;
+}
+
+/***************************************************************
+ *  Toolbar fired EV_ASK_QUESTION — opens a yes/no dialog and
+ *  reports the answer via a follow-up info toast.  Smoke test
+ *  for yui_shell_confirm_yesno + Escape stack.
+ ***************************************************************/
+function ac_ask_question(gobj, event, kw, src)
+{
+    let shell = gobj_read_pointer_attr(gobj, "shell");
+    if(!shell) {
+        return 0;
+    }
+    yui_shell_confirm_yesno(
+        shell,
+        "Is the new shell working as expected?",
+        { title: "A small smoke check" }
+    ).then(answer => {
+        let msg = answer ? "Glad to hear it!" : "Noted — check the console.";
+        yui_shell_show_info(shell, msg);
+    });
+    return 0;
+}
+
 
 
 
@@ -225,7 +269,9 @@ function create_gclass(gclass_name)
      *---------------------------------------------*/
     const states = [
         ["ST_IDLE", [
-            ["EV_TOGGLE_LANGUAGE", ac_toggle_language, null]
+            ["EV_TOGGLE_LANGUAGE", ac_toggle_language, null],
+            ["EV_SHOW_HELLO",      ac_show_hello,      null],
+            ["EV_ASK_QUESTION",    ac_ask_question,    null]
         ]]
     ];
 
@@ -233,7 +279,9 @@ function create_gclass(gclass_name)
      *          Events
      *---------------------------------------------*/
     const event_types = [
-        ["EV_TOGGLE_LANGUAGE", 0]
+        ["EV_TOGGLE_LANGUAGE", 0],
+        ["EV_SHOW_HELLO",      0],
+        ["EV_ASK_QUESTION",    0]
     ];
 
     __gclass__ = gclass_create(

--- a/kernel/js/lib-yui/test-app/src/c_test_lang.js
+++ b/kernel/js/lib-yui/test-app/src/c_test_lang.js
@@ -59,6 +59,8 @@ const DICT_ES = {
     "Quick: Alerts":     "Rápido: Alertas",
     "Quick: Settings":   "Rápido: Ajustes",
     "Home":              "Inicio",
+    "Hello":             "Hola",
+    "Ask":               "Preguntar",
     "Open menu":         "Abrir menú",
     "Open quick menu":   "Abrir menú rápido",
     "ES/EN":             "EN/ES",

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -26,10 +26,11 @@ import {
     register_c_timer,
 } from "@yuneta/gobj-js";
 
-import {
+import * as yuneta_lib_yui from "@yuneta/lib-yui";
+const {
     register_c_yui_shell,
     register_c_yui_nav,
-} from "@yuneta/lib-yui";
+} = yuneta_lib_yui;
 
 import {register_c_test_view} from "./c_test_view.js";
 import {register_c_test_lang} from "./c_test_lang.js";
@@ -110,6 +111,14 @@ function main()
      *  the EV_TOGGLE_LANGUAGE subscription is registered before the
      *  user can click the toolbar button. */
     gobj_start(test_lang);
+
+    /*  Test bridge — the e2e suite drives helpers like
+     *  yui_shell_show_modal that have no toolbar entry.  Exposing
+     *  them on `window` lets Playwright's page.evaluate() reach
+     *  them in `vite preview` mode (where /@fs imports are not
+     *  served).  Test-app only — don't ship in production. */
+    window.__lib_yui__ = yuneta_lib_yui;
+    window.__shell__   = shell;
 }
 
 window.addEventListener("load", () => {

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -37,8 +37,9 @@ import {register_c_test_lang} from "./c_test_lang.js";
 import "bulma/css/bulma.css";
 import "@yuneta/lib-yui/src/c_yui_shell.css";
 
-import app_config          from "./app_config.json";
+import app_config           from "./app_config.json";
 import app_config_accordion from "./app_config_accordion.json";
+import app_config_multimenu from "./app_config_multimenu.json";
 
 
 function pick_config()
@@ -46,6 +47,7 @@ function pick_config()
     let q = new URLSearchParams(window.location.search);
     switch(q.get("preset")) {
         case "accordion": return app_config_accordion;
+        case "multimenu": return app_config_multimenu;
         default:          return app_config;
     }
 }

--- a/kernel/js/lib-yui/test-app/src/main.js
+++ b/kernel/js/lib-yui/test-app/src/main.js
@@ -40,6 +40,7 @@ import "@yuneta/lib-yui/src/c_yui_shell.css";
 import app_config           from "./app_config.json";
 import app_config_accordion from "./app_config_accordion.json";
 import app_config_multimenu from "./app_config_multimenu.json";
+import app_config_invalid   from "./app_config_invalid.json";
 
 
 function pick_config()
@@ -48,6 +49,7 @@ function pick_config()
     switch(q.get("preset")) {
         case "accordion": return app_config_accordion;
         case "multimenu": return app_config_multimenu;
+        case "invalid":   return app_config_invalid;
         default:          return app_config;
     }
 }

--- a/kernel/js/lib-yui/tests-e2e/boot.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/boot.spec.mjs
@@ -1,0 +1,59 @@
+/***********************************************************************
+ *          boot.spec.mjs
+ *
+ *      Smoke: the test-app boots clean, the default route /dash/ov
+ *      renders the Overview card in the centre stage, and there are
+ *      no console errors during the load.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+test.describe("boot", () => {
+
+    test("default preset lands on /dash/ov with the Overview card", async ({ page }) => {
+        const console_errors = [];
+        page.on("console", msg => {
+            if(msg.type() === "error") {
+                console_errors.push(msg.text());
+            }
+        });
+
+        await page.goto("/");
+
+        /*  The shell publishes EV_ROUTE_CHANGED right after boot; once
+         *  it has, the centre stage holds the Overview card. */
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card).toBeVisible();
+        await expect(card.locator("h1")).toHaveText("Overview");
+
+        /*  The hash mirrors current_route. */
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+
+        /*  The primary nav has its active item highlighted (Dashboard). */
+        let active = page.locator('aside[aria-label="primary"] .menu-list a.is-active').first();
+        await expect(active).toBeVisible();
+        await expect(active.locator(".yui-nav-label")).toHaveText("Dashboard");
+
+        /*  No console errors during boot. */
+        expect(console_errors).toEqual([]);
+    });
+
+    test("accordion preset boots and the Dashboard branch is auto-expanded", async ({ page }) => {
+        await page.goto("/?preset=accordion");
+
+        /*  Accordion lives in the left zone (desktop viewport from the
+         *  default Chromium project). */
+        let accordion = page.locator('aside[aria-label="tree"]');
+        await expect(accordion).toBeVisible();
+
+        /*  The Dashboard heading should be the auto-expanded one (the
+         *  /dash/ov route falls under it). */
+        let dash_head = accordion.locator('.yui-accordion-head[data-item-id="dash"]');
+        await expect(dash_head).toHaveAttribute("aria-expanded", "true");
+
+        /*  And the Overview card lands in the centre stage. */
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card.locator("h1")).toHaveText("Overview");
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/breakpoint.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/breakpoint.spec.mjs
@@ -1,0 +1,60 @@
+/***********************************************************************
+ *          breakpoint.spec.mjs
+ *
+ *      Smoke for the responsive zone visibility driven by Bulma
+ *      breakpoints.
+ *
+ *      Default preset (see app_config.json):
+ *          left   → menu.primary,  show_on >= desktop  (≥ 1024 px)
+ *          bottom → menu.primary,  show_on < desktop   (< 1024 px)
+ *          top    → toolbar,       show_on >= tablet   (≥ 769 px)
+ *
+ *      The shell hides zones with custom classes
+ *      `.yui-hidden-mobile` / `.yui-hidden-tablet-only` / etc., each
+ *      backed by a `@media` rule in c_yui_shell.css.  We assert
+ *      visibility through the layout — the actual presence of the
+ *      computed style is a CSS concern of the browser.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+test.describe("breakpoint swap", () => {
+
+    test("desktop (1280×720): primary menu lives in `left`, bottom is hidden", async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.goto("/");
+
+        let left   = page.locator('.yui-zone-left   aside[aria-label="primary"]');
+        let bottom = page.locator('.yui-zone-bottom .yui-nav-iconbar');
+
+        await expect(left).toBeVisible();
+        await expect(bottom).toBeHidden();
+    });
+
+    test("mobile (480×800): primary menu lives in `bottom`, left is hidden", async ({ page }) => {
+        await page.setViewportSize({ width: 480, height: 800 });
+        await page.goto("/");
+
+        let left   = page.locator('.yui-zone-left   aside[aria-label="primary"]');
+        let bottom = page.locator('.yui-zone-bottom .yui-nav-iconbar');
+
+        await expect(bottom).toBeVisible();
+        await expect(left).toBeHidden();
+    });
+
+    test("tablet (800×600): the toolbar appears, but primary stays at `bottom`", async ({ page }) => {
+        await page.setViewportSize({ width: 800, height: 600 });
+        await page.goto("/");
+
+        let toolbar = page.locator(".yui-zone-top .yui-toolbar");
+        let bottom  = page.locator('.yui-zone-bottom .yui-nav-iconbar');
+        let left    = page.locator('.yui-zone-left   aside[aria-label="primary"]');
+
+        /*  769 ≤ width < 1024 → tablet: toolbar visible, primary at
+         *  bottom (icon-bar), left hidden. */
+        await expect(toolbar).toBeVisible();
+        await expect(bottom).toBeVisible();
+        await expect(left).toBeHidden();
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/drawer.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/drawer.spec.mjs
@@ -1,0 +1,89 @@
+/***********************************************************************
+ *          drawer.spec.mjs
+ *
+ *      Smoke for the off-canvas drawer + the Escape priority chain.
+ *      Today only one overlay class lives in the chain (the drawer);
+ *      modal/popup tests will land alongside #4.
+ *
+ *      The test viewport is the Playwright default (Desktop Chrome /
+ *      Desktop Firefox). The drawer is mounted on the overlay layer
+ *      and is opened explicitly from the toolbar's burger button —
+ *      it is not tied to a breakpoint.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+async function open_drawer_via_burger(page)
+{
+    await page.locator(
+        '.yui-toolbar [data-toolbar-item-id="burger"]'
+    ).click();
+}
+
+
+test.describe("drawer + Escape priority chain", () => {
+
+    test("burger opens the drawer; Escape closes it; focus is restored", async ({ page }) => {
+        await page.goto("/");
+
+        let drawer = page.locator(".yui-drawer");
+        await expect(drawer).not.toHaveClass(/is-active/);
+
+        /*  Click the burger; the drawer becomes active. */
+        let burger = page.locator(
+            '.yui-toolbar [data-toolbar-item-id="burger"]'
+        );
+        await burger.click();
+        await expect(drawer).toHaveClass(/is-active/);
+
+        /*  Focus moves into the drawer panel (focus-trap activate). */
+        let focus_inside_panel = await page.evaluate(() => {
+            let panel = document.querySelector(".yui-drawer-panel");
+            return panel ? panel.contains(document.activeElement) : false;
+        });
+        expect(focus_inside_panel).toBe(true);
+
+        /*  Escape closes it. */
+        await page.keyboard.press("Escape");
+        await expect(drawer).not.toHaveClass(/is-active/);
+
+        /*  Focus is restored to the burger button. */
+        let burger_focused = await page.evaluate(() => {
+            let b = document.querySelector('[data-toolbar-item-id="burger"]');
+            return document.activeElement === b;
+        });
+        expect(burger_focused).toBe(true);
+    });
+
+    test("clicking the backdrop closes the drawer through the canonical close path", async ({ page }) => {
+        await page.goto("/");
+        await open_drawer_via_burger(page);
+
+        let drawer = page.locator(".yui-drawer");
+        await expect(drawer).toHaveClass(/is-active/);
+
+        /*  Click far enough to the right that we hit the backdrop,
+         *  not the 18rem-wide panel that sits stacked on top of it.
+         *  page.mouse.click() takes absolute viewport coordinates;
+         *  the default Playwright viewport is 1280×720. */
+        await page.mouse.click(900, 400);
+        await expect(drawer).not.toHaveClass(/is-active/);
+
+        /*  Stack popped: a follow-up Escape must be a no-op. */
+        await page.keyboard.press("Escape");
+        await expect(drawer).not.toHaveClass(/is-active/);
+    });
+
+    test("Escape with nothing open is a no-op (URL hash unchanged)", async ({ page }) => {
+        await page.goto("/");
+        /*  Wait for the shell's initial navigate_to to settle the
+         *  hash (Firefox can return from goto() before the
+         *  mt_start->history.replaceState() fires). */
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+        let url_before = page.url();
+        await page.keyboard.press("Escape");
+        await page.keyboard.press("Escape");
+        expect(page.url()).toBe(url_before);
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
@@ -80,4 +80,35 @@ test.describe("live i18n", () => {
         await expect(toolbar_ask).toHaveText("Ask");
     });
 
+    test("modals/toasts opened AFTER a language toggle render in the active language", async ({ page }) => {
+        await page.goto("/");
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+
+        /*  Toggle to Spanish. */
+        await page.locator('[data-toolbar-item-id="lang"]').click();
+
+        /*  Open the toast — it must be in Spanish on the first frame
+         *  (caller passes opts.t, helper applies refresh_language to
+         *  the new node before returning). */
+        await page.locator('[data-toolbar-item-id="say-hello"]').click();
+        let toast = page.locator(".yui-layer-notification .notification");
+        await expect(toast).toContainText("¡Hola desde el shell!");
+        await toast.locator(".delete").click();
+
+        /*  Open the dialog.  Title, body and buttons in Spanish. */
+        await page.locator('[data-toolbar-item-id="ask-question"]').click();
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal.locator(".modal-card-title")).toHaveText("Una pequeña comprobación");
+        await expect(modal.locator(".modal-card-body")).toContainText(
+            "¿Funciona el nuevo shell como esperabas?"
+        );
+        await expect(modal.locator('button[data-modal-button-value="yes"]')).toHaveText("Sí");
+        await expect(modal.locator('button[data-modal-button-value="no"]')).toHaveText("No");
+
+        /*  Click "Sí" — the follow-up toast is also in Spanish. */
+        await modal.locator('button[data-modal-button-value="yes"]').click();
+        let follow = page.locator(".yui-layer-notification .notification").last();
+        await expect(follow).toContainText("¡Me alegro!");
+    });
+
 });

--- a/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
@@ -1,0 +1,71 @@
+/***********************************************************************
+ *          i18n.spec.mjs
+ *
+ *      Smoke for the canonical language switch
+ *      (`refresh_language(shell.$container, t)`).
+ *
+ *      The test-app's toolbar has an ES/EN button that fires
+ *      `EV_TOGGLE_LANGUAGE`; the C_TEST_LANG controller flips
+ *      between two trivial dictionaries (EN identity / ES map) and
+ *      calls `refresh_language` on the shell's container.
+ *
+ *      What we assert:
+ *          - menu labels swap (Dashboard → Panel),
+ *          - secondary-nav heading swaps (Dashboard → Panel),
+ *          - toolbar button labels swap (Home → Inicio),
+ *          - the active item highlight survives the swap (no DOM
+ *            rebuild — just `[data-i18n]` text-node retraduction).
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+test.describe("live i18n", () => {
+
+    test("ES/EN button flips every translatable label and preserves the active highlight", async ({ page }) => {
+        await page.goto("/");
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+
+        /*  Anchors. */
+        let primary_dash = page.locator(
+            'aside[aria-label="primary"] a[data-item-id="dash"] .yui-nav-label'
+        ).first();
+        let toolbar_home = page.locator(
+            '[data-toolbar-item-id="home"] span[data-i18n="Home"]'
+        );
+        let secondary_heading = page.locator(
+            '[data-nav-zone="right"][aria-label="Dashboard"] .menu-label'
+        );
+
+        /*  Initial language: English. */
+        await expect(primary_dash).toHaveText("Dashboard");
+        await expect(toolbar_home).toHaveText("Home");
+        await expect(secondary_heading).toHaveText("Dashboard");
+
+        /*  Snapshot the active highlight before the swap. */
+        let active_before = await page.locator(
+            'aside[aria-label="primary"] li.is-active a'
+        ).first().getAttribute("data-item-id");
+
+        /*  Click ES/EN. */
+        await page.locator('[data-toolbar-item-id="lang"]').click();
+
+        /*  Spanish dictionary applied. */
+        await expect(primary_dash).toHaveText("Panel");
+        await expect(toolbar_home).toHaveText("Inicio");
+        await expect(secondary_heading).toHaveText("Panel");
+
+        /*  Active highlight unchanged — refresh_language only touches
+         *  `[data-i18n]` text nodes, the `is-active` class on the
+         *  parent <li> survives. */
+        let active_after = await page.locator(
+            'aside[aria-label="primary"] li.is-active a'
+        ).first().getAttribute("data-item-id");
+        expect(active_after).toBe(active_before);
+
+        /*  Click again — flips back to English. */
+        await page.locator('[data-toolbar-item-id="lang"]').click();
+        await expect(primary_dash).toHaveText("Dashboard");
+        await expect(toolbar_home).toHaveText("Home");
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/i18n.spec.mjs
@@ -32,6 +32,12 @@ test.describe("live i18n", () => {
         let toolbar_home = page.locator(
             '[data-toolbar-item-id="home"] span[data-i18n="Home"]'
         );
+        let toolbar_hello = page.locator(
+            '[data-toolbar-item-id="say-hello"] span[data-i18n="Hello"]'
+        );
+        let toolbar_ask = page.locator(
+            '[data-toolbar-item-id="ask-question"] span[data-i18n="Ask"]'
+        );
         let secondary_heading = page.locator(
             '[data-nav-zone="right"][aria-label="Dashboard"] .menu-label'
         );
@@ -39,6 +45,8 @@ test.describe("live i18n", () => {
         /*  Initial language: English. */
         await expect(primary_dash).toHaveText("Dashboard");
         await expect(toolbar_home).toHaveText("Home");
+        await expect(toolbar_hello).toHaveText("Hello");
+        await expect(toolbar_ask).toHaveText("Ask");
         await expect(secondary_heading).toHaveText("Dashboard");
 
         /*  Snapshot the active highlight before the swap. */
@@ -52,6 +60,8 @@ test.describe("live i18n", () => {
         /*  Spanish dictionary applied. */
         await expect(primary_dash).toHaveText("Panel");
         await expect(toolbar_home).toHaveText("Inicio");
+        await expect(toolbar_hello).toHaveText("Hola");
+        await expect(toolbar_ask).toHaveText("Preguntar");
         await expect(secondary_heading).toHaveText("Panel");
 
         /*  Active highlight unchanged — refresh_language only touches
@@ -66,6 +76,8 @@ test.describe("live i18n", () => {
         await page.locator('[data-toolbar-item-id="lang"]').click();
         await expect(primary_dash).toHaveText("Dashboard");
         await expect(toolbar_home).toHaveText("Home");
+        await expect(toolbar_hello).toHaveText("Hello");
+        await expect(toolbar_ask).toHaveText("Ask");
     });
 
 });

--- a/kernel/js/lib-yui/tests-e2e/lifecycle.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/lifecycle.spec.mjs
@@ -1,0 +1,84 @@
+/***********************************************************************
+ *          lifecycle.spec.mjs
+ *
+ *      Smoke for the per-item lifecycle (`eager` / `keep_alive` /
+ *      `lazy_destroy`).  C_TEST_VIEW renders its monotonic
+ *      `instance #` in the card body, so we can tell whether the
+ *      view was destroyed and rebuilt or just hidden.
+ *
+ *      Default preset:
+ *          /dash/ov     → lifecycle:"keep_alive"   (Overview)
+ *          /dash/alerts → lifecycle:"lazy_destroy" (Alerts)
+ *          /help        → lifecycle:"eager"        (preinstantiated)
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+async function instance_of(page, route_match)
+{
+    let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+    let txt = await card.locator("p.is-size-7").innerText();
+    let m = /instance #(\d+)/.exec(txt);
+    if(!m) {
+        throw new Error(`No instance # in ${route_match}: '${txt}'`);
+    }
+    return Number(m[1]);
+}
+
+
+test.describe("lifecycle", () => {
+
+    test("keep_alive: revisiting the same route reuses the instance", async ({ page }) => {
+        await page.goto("/");
+        let n0 = await instance_of(page, "/dash/ov");
+
+        await page.goto("/#/reports/daily");
+        await expect(page).toHaveURL(/#\/reports\/daily$/);
+
+        await page.goto("/#/dash/ov");
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+        let n1 = await instance_of(page, "/dash/ov");
+
+        expect(n1).toBe(n0);
+    });
+
+    test("lazy_destroy: revisiting the same route mints a new instance", async ({ page }) => {
+        await page.goto("/#/dash/alerts");
+        let n0 = await instance_of(page, "/dash/alerts");
+
+        await page.goto("/#/dash/ov");
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+
+        await page.goto("/#/dash/alerts");
+        await expect(page).toHaveURL(/#\/dash\/alerts$/);
+        let n1 = await instance_of(page, "/dash/alerts");
+
+        expect(n1).toBeGreaterThan(n0);
+    });
+
+    test("eager: the Help view is preinstantiated before its first visit", async ({ page }) => {
+        await page.goto("/");
+
+        /*  At this point the centre stage shows /dash/ov (Overview).
+         *  Help is preinstantiated hidden in the same zone.  Find it
+         *  via the title attribute of the gobj name embedded in the
+         *  paragraph; its instance # exists already. */
+        let hidden_help = page.locator(
+            '.yui-zone-center .view-card.is-hidden:has(h1:has-text("Help (eager)"))'
+        );
+        await expect(hidden_help).toHaveCount(1);
+
+        let help_txt = await hidden_help.locator("p.is-size-7").innerText();
+        let help_m = /instance #(\d+)/.exec(help_txt);
+        expect(help_m).not.toBeNull();
+        let preinst_id = Number(help_m[1]);
+
+        /*  Now visit Help.  The instance # must be the same as the
+         *  preinstantiated one — the eager view was just unhidden,
+         *  not rebuilt. */
+        await page.goto("/#/help");
+        let n_help = await instance_of(page, "/help");
+        expect(n_help).toBe(preinst_id);
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
@@ -1,0 +1,100 @@
+/***********************************************************************
+ *          modals.spec.mjs
+ *
+ *      Smoke for the new modal/notification helpers + the
+ *      cross-overlay Escape priority chain (modal over drawer).
+ *
+ *      Drives the API through the test-app's toolbar buttons
+ *      (`Hello` → `EV_SHOW_HELLO` → `yui_shell_show_info`,
+ *      `Ask` → `EV_ASK_QUESTION` → `yui_shell_confirm_yesno`),
+ *      so we exercise the same path real apps would.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+test.describe("notifications + modals", () => {
+
+    test("Hello toolbar item paints a Bulma .notification on the notification layer", async ({ page }) => {
+        await page.goto("/");
+
+        let toast = page.locator(".yui-layer-notification .notification");
+        await expect(toast).toHaveCount(0);
+
+        await page.locator('[data-toolbar-item-id="say-hello"]').click();
+
+        await expect(toast).toHaveCount(1);
+        await expect(toast).toContainText("Hello from the shell!");
+        await expect(toast).toHaveClass(/is-info/);
+
+        /*  Manual dismiss via the .delete button. */
+        await toast.locator(".delete").click();
+        await expect(toast).toHaveCount(0);
+    });
+
+    test("Ask toolbar item opens a yes/no dialog; clicking Yes resolves and shows a follow-up toast", async ({ page }) => {
+        await page.goto("/");
+
+        await page.locator('[data-toolbar-item-id="ask-question"]').click();
+
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal).toBeVisible();
+        await expect(modal.locator(".modal-card-title")).toHaveText("A small smoke check");
+
+        /*  Yes button — the primary-styled one. */
+        await modal.locator('button[data-modal-button-value="yes"]').click();
+        await expect(modal).toHaveCount(0);
+
+        let toast = page.locator(".yui-layer-notification .notification");
+        await expect(toast).toContainText("Glad to hear it!");
+    });
+
+    test("Escape on an open dialog dismisses it (= clicks the last button)", async ({ page }) => {
+        await page.goto("/");
+
+        await page.locator('[data-toolbar-item-id="ask-question"]').click();
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal).toBeVisible();
+
+        await page.keyboard.press("Escape");
+        await expect(modal).toHaveCount(0);
+
+        /*  yes/no's last button = "no" → "Noted — check the console.". */
+        let toast = page.locator(".yui-layer-notification .notification");
+        await expect(toast).toContainText("Noted");
+    });
+
+    test("Modal over drawer: first Escape closes the modal, second Escape closes the drawer", async ({ page }) => {
+        await page.goto("/");
+
+        /*  1. Open the drawer via the burger. */
+        await page.locator('[data-toolbar-item-id="burger"]').click();
+        let drawer = page.locator(".yui-drawer");
+        await expect(drawer).toHaveClass(/is-active/);
+
+        /*  2. The drawer (z-index 18) occludes the toolbar, so a real
+         *  pointer click on the Ask button is blocked.  Use a
+         *  synthetic .click() inside the page — Element.click()
+         *  dispatches the click event directly on the target without
+         *  hit-testing.  Real apps would use the public modal API
+         *  (yui_shell_confirm_yesno) instead; this is the e2e shortcut. */
+        await page.evaluate(() => {
+            let btn = document.querySelector('[data-toolbar-item-id="ask-question"]');
+            if(btn) {
+                btn.click();
+            }
+        });
+
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal).toBeVisible();
+
+        /*  3. First Escape closes the modal — drawer must remain open. */
+        await page.keyboard.press("Escape");
+        await expect(modal).toHaveCount(0);
+        await expect(drawer).toHaveClass(/is-active/);
+
+        /*  4. Second Escape closes the drawer. */
+        await page.keyboard.press("Escape");
+        await expect(drawer).not.toHaveClass(/is-active/);
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
@@ -63,6 +63,57 @@ test.describe("notifications + modals", () => {
         await expect(toast).toContainText("Noted");
     });
 
+    test("yui_shell_show_modal: Tab cycles into the .modal-close button (not just .modal-content)", async ({ page }) => {
+        await page.goto("/");
+
+        /*  Open a non-blocking modal via the test bridge (window
+         *  exposes lib-yui so we can call helpers without a toolbar
+         *  entry). */
+        await page.evaluate(() => {
+            window.__test_modal__ = window.__lib_yui__.yui_shell_show_modal(
+                window.__shell__, "Hello modal"
+            );
+        });
+
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal).toBeVisible();
+
+        /*  The close button must be in the focus-trap's pool.  We
+         *  assert it is reachable via the same selector
+         *  activate_focus_trap_on uses internally. */
+        let reachable = await page.evaluate(() => {
+            let m = document.querySelector(".yui-layer-modal .modal.is-active");
+            let close_btn = m && m.querySelector(".modal-close");
+            if(!m || !close_btn) {
+                return false;
+            }
+            const SEL = "a[href], button:not([disabled]), input:not([disabled])," +
+                        " select:not([disabled]), textarea:not([disabled])," +
+                        " [tabindex]:not([tabindex=\"-1\"])";
+            let nodes = Array.from(m.querySelectorAll(SEL));
+            return nodes.includes(close_btn);
+        });
+        expect(reachable).toBe(true);
+
+        /*  Sanity: pressing Tab from the close button itself should
+         *  wrap to the first focusable inside the modal (focus stays
+         *  within $modal, never escapes to elements outside the
+         *  modal layer). */
+        await page.evaluate(() => {
+            let m = document.querySelector(".yui-layer-modal .modal.is-active");
+            m.querySelector(".modal-close").focus();
+        });
+        await page.keyboard.press("Tab");
+        let still_inside = await page.evaluate(() => {
+            let m = document.querySelector(".yui-layer-modal .modal.is-active");
+            return m ? m.contains(document.activeElement) : false;
+        });
+        expect(still_inside).toBe(true);
+
+        await page.evaluate(() => window.__test_modal__.close());
+        await expect(modal).toHaveCount(0);
+    });
+
     test("Modal over drawer: first Escape closes the modal, second Escape closes the drawer", async ({ page }) => {
         await page.goto("/");
 

--- a/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/modals.spec.mjs
@@ -114,6 +114,52 @@ test.describe("notifications + modals", () => {
         await expect(modal).toHaveCount(0);
     });
 
+    test("Modal over drawer: Tab cycles WITHIN the modal only (drawer's trap defers)", async ({ page }) => {
+        await page.goto("/");
+
+        /*  1. Open the drawer via the burger. */
+        await page.locator('[data-toolbar-item-id="burger"]').click();
+        let drawer = page.locator(".yui-drawer");
+        await expect(drawer).toHaveClass(/is-active/);
+
+        /*  2. Open a yes/no/cancel dialog programmatically (the
+         *  drawer occludes the toolbar so we can't click Ask). */
+        await page.evaluate(async () => {
+            window.__lib_yui__.yui_shell_confirm_yesnocancel(
+                window.__shell__,
+                "Save changes?",
+                { title: "Confirm" }
+            );
+        });
+
+        let modal = page.locator(".yui-layer-modal .modal.is-active");
+        await expect(modal).toBeVisible();
+        let no_btn = modal.locator('button[data-modal-button-value="no"]');
+        let cancel_btn = modal.locator('button[data-modal-button-value="cancel"]');
+
+        /*  3. Focus the middle "No" button.  Press Tab — it must
+         *  land on Cancel (the next focusable inside the modal),
+         *  not snap back to the modal's first focusable.  Without
+         *  the LIFO trap-stack fix, the drawer's trap also fires
+         *  and forces focus to its first item before the modal
+         *  trap runs, which then snaps back to "Yes" every time. */
+        await no_btn.focus();
+        let active_before = await page.evaluate(() => document.activeElement.getAttribute("data-modal-button-value"));
+        expect(active_before).toBe("no");
+
+        await page.keyboard.press("Tab");
+
+        let active_after = await page.evaluate(() => document.activeElement.getAttribute("data-modal-button-value"));
+        expect(active_after).toBe("cancel");
+
+        /*  Cleanup: dismiss with Escape (resolves with cancel) and
+         *  then close the drawer. */
+        await page.keyboard.press("Escape");
+        await expect(modal).toHaveCount(0);
+        await page.keyboard.press("Escape");
+        await expect(drawer).not.toHaveClass(/is-active/);
+    });
+
     test("Modal over drawer: first Escape closes the modal, second Escape closes the drawer", async ({ page }) => {
         await page.goto("/");
 

--- a/kernel/js/lib-yui/tests-e2e/multimenu.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/multimenu.spec.mjs
@@ -69,4 +69,42 @@ test.describe("multiple primary-style menus", () => {
         await expect(admin_secondary.locator('a[data-route="/dash/ov"]')).toHaveCount(0);
     });
 
+    test("primary navs do NOT cross-highlight items with the same id across menus", async ({ page }) => {
+        /*  Both menus declare an item id="dash"; navigating to a
+         *  route owned by menu.admin must highlight ONLY menu.admin's
+         *  item — not menu.primary's "dash" item.  Without the
+         *  menu_id-scoped filter in ac_route_changed, both would
+         *  light up. */
+        await page.goto("/?preset=multimenu#/admin/dash/users");
+
+        /*  Wait for the centre stage to show the admin card so we
+         *  know navigate_to has settled. */
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card.locator("h1")).toHaveText("Admin / Users");
+
+        /*  Exactly one active item across both primary navs, and it
+         *  must be in menu.admin. */
+        let admin_active = page.locator(
+            'aside[aria-label="admin"] li.is-active a[data-item-id="dash"]'
+        );
+        let primary_active = page.locator(
+            'aside[aria-label="primary"] li.is-active'
+        );
+        await expect(admin_active).toHaveCount(1);
+        await expect(primary_active).toHaveCount(0);
+
+        /*  And the inverse: navigate to a primary-owned route. */
+        await page.goto("/?preset=multimenu#/dash/alerts");
+        await expect(card.locator("h1")).toHaveText("Alerts");
+
+        let primary_active_2 = page.locator(
+            'aside[aria-label="primary"] li.is-active a[data-item-id="dash"]'
+        );
+        let admin_active_2 = page.locator(
+            'aside[aria-label="admin"] li.is-active'
+        );
+        await expect(primary_active_2).toHaveCount(1);
+        await expect(admin_active_2).toHaveCount(0);
+    });
+
 });

--- a/kernel/js/lib-yui/tests-e2e/multimenu.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/multimenu.spec.mjs
@@ -1,0 +1,72 @@
+/***********************************************************************
+ *          multimenu.spec.mjs
+ *
+ *      Regression for TODO #5 — `instantiate_menus` walks every menu
+ *      mounted via a "menu.<id>" host, not just `menu.primary`.
+ *
+ *      The `multimenu` preset declares two primary-style menus
+ *      side-by-side:
+ *
+ *          menu.primary   (left / bottom)   item id "dash"
+ *          menu.admin     (right / bottom-sub) item id "dash"  ← same id!
+ *
+ *      Each item declares a submenu with its own `render` block.
+ *      The shell synthesises the secondary-nav menu_id as
+ *      `secondary.<menu_id>.<item.id>` so the two trees never
+ *      collide; only the secondary nav owned by the active route's
+ *      menu is visible at a time.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+function nav_root_for(page, menu_id)
+{
+    return page.locator(`aside[aria-label="${menu_id}"]`);
+}
+
+
+test.describe("multiple primary-style menus", () => {
+
+    test("each menu's secondary nav is auto-instantiated and scoped by menu_id", async ({ page }) => {
+        await page.goto("/?preset=multimenu");
+
+        /*  The two top-level menus are both rendered as `aside`s with
+         *  their own aria-label (the menu id). */
+        await expect(nav_root_for(page, "primary").first()).toBeVisible();
+        await expect(nav_root_for(page, "admin").first()).toBeVisible();
+
+        /*  Two secondary navs were built (one per menu × item that
+         *  declares `submenu.render`).  They are tabs on top-sub. */
+        let primary_secondary = page.locator(
+            '[data-nav-zone="top-sub"][aria-label="Dashboard"]'
+        );
+        let admin_secondary = page.locator(
+            '[data-nav-zone="top-sub"][aria-label="Admin: Dashboard"]'
+        );
+
+        /*  Initial route: /dash/ov → menu.primary owns it →
+         *  menu.primary's secondary nav is shown, menu.admin's is
+         *  hidden. */
+        await expect(primary_secondary).not.toHaveClass(/is-hidden/);
+        await expect(admin_secondary).toHaveClass(/is-hidden/);
+
+        /*  Navigate into the admin tree. */
+        await page.goto("/?preset=multimenu#/admin/dash/users");
+
+        /*  Centre stage updates. */
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card.locator("h1")).toHaveText("Admin / Users");
+
+        /*  Now the admin secondary should be visible, primary's
+         *  hidden — the visibility flipped strictly by menu_id, not
+         *  by the duplicated "dash" item id. */
+        await expect(admin_secondary).not.toHaveClass(/is-hidden/);
+        await expect(primary_secondary).toHaveClass(/is-hidden/);
+
+        /*  And the secondary's items belong to the right tree. */
+        await expect(admin_secondary.locator('a[data-route="/admin/dash/users"]')).toBeVisible();
+        await expect(admin_secondary.locator('a[data-route="/admin/dash/billing"]')).toBeVisible();
+        await expect(admin_secondary.locator('a[data-route="/dash/ov"]')).toHaveCount(0);
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/navigation.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/navigation.spec.mjs
@@ -1,0 +1,84 @@
+/***********************************************************************
+ *          navigation.spec.mjs
+ *
+ *      Smoke: clicking through every primary item changes the centre-
+ *      stage card and the active highlight, and the URL hash mirrors
+ *      the active route.  Covers click-driven and hash-driven navigation
+ *      both, plus the back/forward buttons.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+/*  Match the test-app's default app_config.json — keep in sync if items
+ *  are added or renamed. */
+const PRIMARY_ROUTES = [
+    { label: "Dashboard", route: "/dash",     /* container; redirects to /dash/ov */ landing: "/dash/ov", title: "Overview" },
+    { label: "Reports",   route: "/reports",                                          landing: "/reports/daily", title: "Daily reports" },
+    { label: "Settings",  route: "/settings",                                         landing: "/settings",      title: "Settings" },
+    { label: "Help",      route: "/help",                                             landing: "/help",          title: "Help (eager)" }
+];
+
+
+async function expect_landed(page, item)
+{
+    await expect(page).toHaveURL(new RegExp(`#${item.landing.replace(/\//g, "\\/")}$`));
+    let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+    await expect(card.locator("h1")).toHaveText(item.title);
+}
+
+
+test.describe("navigation", () => {
+
+    test("clicking each primary item updates the URL hash and the centre stage", async ({ page }) => {
+        await page.goto("/");
+
+        for(let item of PRIMARY_ROUTES) {
+            let link = page.locator(
+                `aside[aria-label="primary"] .menu-list a[data-item-id="${item.route.replace(/^\//, "").split("/")[0]}"]`
+            ).first();
+            await link.click();
+            await expect_landed(page, item);
+        }
+    });
+
+    test("hash navigation (typed URL) lands on the right card", async ({ page }) => {
+        await page.goto("/#/reports/monthly");
+
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card.locator("h1")).toHaveText("Monthly reports");
+        await expect(page).toHaveURL(/#\/reports\/monthly$/);
+    });
+
+    test("browser back / forward replays the route history", async ({ page }) => {
+        await page.goto("/");
+
+        /*  Build a 3-step history: /dash/ov → /reports/daily → /settings */
+        await page.locator(
+            'aside[aria-label="primary"] .menu-list a[data-item-id="reports"]'
+        ).first().click();
+        await expect(page).toHaveURL(/#\/reports\/daily$/);
+
+        await page.locator(
+            'aside[aria-label="primary"] .menu-list a[data-item-id="settings"]'
+        ).first().click();
+        await expect(page).toHaveURL(/#\/settings$/);
+
+        await page.goBack();
+        await expect(page).toHaveURL(/#\/reports\/daily$/);
+
+        await page.goBack();
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+
+        await page.goForward();
+        await expect(page).toHaveURL(/#\/reports\/daily$/);
+    });
+
+    test("submenu container (/dash) redirects to its first sub-item (/dash/ov)", async ({ page }) => {
+        await page.goto("/#/dash");
+
+        await expect(page).toHaveURL(/#\/dash\/ov$/);
+        let card = page.locator(".yui-zone-center .view-card:not(.is-hidden)");
+        await expect(card.locator("h1")).toHaveText("Overview");
+    });
+
+});

--- a/kernel/js/lib-yui/tests-e2e/validator.spec.mjs
+++ b/kernel/js/lib-yui/tests-e2e/validator.spec.mjs
@@ -1,0 +1,39 @@
+/***********************************************************************
+ *          validator.spec.mjs
+ *
+ *      Smoke for `validate_config()` — the system-boundary guard
+ *      the shell runs at the top of mt_start.  Boots the test-app
+ *      with an intentionally broken preset and checks that:
+ *
+ *          - the shell paints the "invalid config" banner instead
+ *            of producing a half-built layout;
+ *          - the console carries the matching log_error lines.
+ ***********************************************************************/
+import { test, expect } from "@playwright/test";
+
+
+test("invalid preset surfaces the config banner and logs every error", async ({ page }) => {
+    let console_errors = [];
+    page.on("console", msg => {
+        if(msg.type() === "error") {
+            console_errors.push(msg.text());
+        }
+    });
+
+    await page.goto("/?preset=invalid");
+
+    /*  The shell should NOT have built navs/views — instead, a Bulma
+     *  `.notification.is-danger` banner appears in the base layer
+     *  carrying the "invalid config" line. */
+    let banner = page.locator(".yui-layer-base .notification.is-danger");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("invalid config");
+
+    /*  Every problem in app_config_invalid.json maps to a log_error
+     *  emitted by validate_config(): the unknown zone id 'centre'
+     *  and the invalid host 'window.foo'.  At least one of them must
+     *  appear in the console. */
+    let joined = console_errors.join("\n");
+    expect(joined).toMatch(/unknown zone 'centre'/);
+    expect(joined).toMatch(/invalid host 'window\.foo'/);
+});

--- a/kernel/js/lib-yui/tests/shell_focus_trap.test.mjs
+++ b/kernel/js/lib-yui/tests/shell_focus_trap.test.mjs
@@ -1,0 +1,237 @@
+/***********************************************************************
+ *          shell_focus_trap.test.mjs
+ *
+ *      Unit tests for the generic focus-trap helper.  Uses a tiny
+ *      hand-rolled DOM stub injected via the second arg of
+ *      `activate_focus_trap_on($panel, doc)` — no extra devDep.
+ ***********************************************************************/
+import { test } from "node:test";
+import assert   from "node:assert/strict";
+
+import {
+    FOCUSABLE_SELECTOR,
+    activate_focus_trap_on,
+} from "../src/shell_focus_trap.js";
+
+
+/***************************************************************
+ *  Minimal stubs.  Just enough to drive the focus-trap module.
+ ***************************************************************/
+function make_focusable(name, opts = {})
+{
+    let calls = [];
+    return {
+        __name: name,
+        focus: () => calls.push(`${name}.focus`),
+        focus_calls: calls,
+        ...opts
+    };
+}
+
+function make_panel(focusables)
+{
+    return {
+        querySelector(_sel) {
+            return focusables[0] || null;
+        },
+        querySelectorAll(_sel) {
+            return focusables;
+        },
+        contains(node) {
+            return focusables.indexOf(node) >= 0;
+        }
+    };
+}
+
+function make_doc(initial_active, body_contains = true)
+{
+    let listeners = [];
+    return {
+        activeElement: initial_active,
+        addEventListener(_t, fn, _opts) { listeners.push(fn); },
+        removeEventListener(_t, fn, _opts) {
+            let i = listeners.indexOf(fn);
+            if(i >= 0) {
+                listeners.splice(i, 1);
+            }
+        },
+        body: {
+            contains: () => body_contains
+        },
+        listeners
+    };
+}
+
+
+test("FOCUSABLE_SELECTOR covers the standard focusable elements", () => {
+    /*  Sanity: just check the string is non-trivial. */
+    assert.ok(FOCUSABLE_SELECTOR.includes("a[href]"));
+    assert.ok(FOCUSABLE_SELECTOR.includes("button:not([disabled])"));
+    assert.ok(FOCUSABLE_SELECTOR.includes("input:not([disabled])"));
+    assert.ok(FOCUSABLE_SELECTOR.includes("[tabindex]:not([tabindex=\"-1\"])"));
+});
+
+test("activate moves focus to the first focusable child of the panel", () => {
+    let first = make_focusable("first");
+    let last  = make_focusable("last");
+    let panel = make_panel([first, last]);
+    let doc   = make_doc(null);
+
+    let release = activate_focus_trap_on(panel, doc);
+
+    assert.deepEqual(first.focus_calls, ["first.focus"]);
+    assert.deepEqual(last.focus_calls, []);
+    /*  Listener registered. */
+    assert.equal(doc.listeners.length, 1);
+
+    release();
+    /*  Listener removed. */
+    assert.equal(doc.listeners.length, 0);
+});
+
+test("Tab from the last focusable wraps to the first", () => {
+    let first = make_focusable("first");
+    let last  = make_focusable("last");
+    let panel = make_panel([first, last]);
+    let doc   = make_doc(null);
+
+    activate_focus_trap_on(panel, doc);
+
+    /*  Reset focus_calls so we only see what the trap does. */
+    first.focus_calls.length = 0;
+    last.focus_calls.length  = 0;
+
+    /*  Pretend `last` is focused now, then user presses Tab. */
+    doc.activeElement = last;
+    let prevented = false;
+    let ev = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault() { prevented = true; }
+    };
+    doc.listeners[0](ev);
+
+    assert.equal(prevented, true);
+    assert.deepEqual(first.focus_calls, ["first.focus"]);
+    assert.deepEqual(last.focus_calls, []);
+});
+
+test("Shift+Tab from the first focusable wraps to the last", () => {
+    let first = make_focusable("first");
+    let last  = make_focusable("last");
+    let panel = make_panel([first, last]);
+    let doc   = make_doc(null);
+
+    activate_focus_trap_on(panel, doc);
+    first.focus_calls.length = 0;
+    last.focus_calls.length  = 0;
+
+    doc.activeElement = first;
+    let prevented = false;
+    let ev = {
+        key: "Tab",
+        shiftKey: true,
+        preventDefault() { prevented = true; }
+    };
+    doc.listeners[0](ev);
+
+    assert.equal(prevented, true);
+    assert.deepEqual(last.focus_calls, ["last.focus"]);
+});
+
+test("non-Tab keys are ignored by the trap", () => {
+    let first = make_focusable("first");
+    let panel = make_panel([first]);
+    let doc   = make_doc(null);
+
+    activate_focus_trap_on(panel, doc);
+    first.focus_calls.length = 0;
+
+    let prevented = false;
+    let ev = {
+        key: "Escape",
+        shiftKey: false,
+        preventDefault() { prevented = true; }
+    };
+    doc.listeners[0](ev);
+
+    assert.equal(prevented, false);
+    assert.deepEqual(first.focus_calls, []);
+});
+
+test("focus jumps into the panel when activeElement is outside", () => {
+    let first = make_focusable("first");
+    let last  = make_focusable("last");
+    let panel = make_panel([first, last]);
+    let doc   = make_doc(null);
+    let outside = make_focusable("outside");
+
+    activate_focus_trap_on(panel, doc);
+    first.focus_calls.length = 0;
+
+    doc.activeElement = outside;   /*  not in panel.contains() */
+
+    let prevented = false;
+    let ev = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault() { prevented = true; }
+    };
+    doc.listeners[0](ev);
+
+    assert.equal(prevented, true);
+    assert.deepEqual(first.focus_calls, ["first.focus"]);
+});
+
+test("release restores the previously-active element", () => {
+    let prev = make_focusable("prev");
+    let inside_first = make_focusable("first");
+    let panel = make_panel([inside_first]);
+    let doc   = make_doc(prev);   /*  prev was active before the trap */
+
+    let release = activate_focus_trap_on(panel, doc);
+    /*  After activation, the trap focuses the first inside element. */
+    assert.deepEqual(inside_first.focus_calls, ["first.focus"]);
+
+    release();
+    assert.deepEqual(prev.focus_calls, ["prev.focus"]);
+});
+
+test("release is idempotent — calling it twice is safe", () => {
+    let panel = make_panel([make_focusable("first")]);
+    let doc   = make_doc(null);
+
+    let release = activate_focus_trap_on(panel, doc);
+    assert.equal(doc.listeners.length, 1);
+
+    release();
+    assert.equal(doc.listeners.length, 0);
+
+    /*  Second release call must not throw and must not double-act. */
+    release();
+    assert.equal(doc.listeners.length, 0);
+});
+
+test("missing $panel returns a no-op release function", () => {
+    let release = activate_focus_trap_on(null, make_doc(null));
+    assert.equal(typeof release, "function");
+    release();   /*  must not throw */
+});
+
+test("an empty panel installs the listener but does nothing on Tab", () => {
+    let panel = make_panel([]);
+    let doc   = make_doc(null);
+
+    activate_focus_trap_on(panel, doc);
+    assert.equal(doc.listeners.length, 1);
+
+    let prevented = false;
+    let ev = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault() { prevented = true; }
+    };
+    doc.listeners[0](ev);
+    /*  No focusables → trap stays out of the way. */
+    assert.equal(prevented, false);
+});

--- a/kernel/js/lib-yui/tests/shell_focus_trap.test.mjs
+++ b/kernel/js/lib-yui/tests/shell_focus_trap.test.mjs
@@ -218,6 +218,70 @@ test("missing $panel returns a no-op release function", () => {
     release();   /*  must not throw */
 });
 
+test("LIFO stacking: only the topmost trap acts on Tab", () => {
+    /*  Two panels active simultaneously.  Pressing Tab must use
+     *  the SECOND trap's panel, not the first — even though both
+     *  listeners fire (capture phase). */
+    let panel_a_first = make_focusable("a-first");
+    let panel_a_last  = make_focusable("a-last");
+    let panel_a = make_panel([panel_a_first, panel_a_last]);
+
+    let panel_b_first = make_focusable("b-first");
+    let panel_b_last  = make_focusable("b-last");
+    let panel_b = make_panel([panel_b_first, panel_b_last]);
+
+    let doc = make_doc(null);
+    activate_focus_trap_on(panel_a, doc);
+    activate_focus_trap_on(panel_b, doc);
+
+    /*  Both listeners are attached. */
+    assert.equal(doc.listeners.length, 2);
+
+    /*  Reset focus_calls so we only see the Tab response. */
+    panel_a_first.focus_calls.length = 0;
+    panel_b_first.focus_calls.length = 0;
+
+    /*  Pretend focus is "outside" both panels.  Press Tab. */
+    doc.activeElement = make_focusable("outside");
+    let ev = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault() {}
+    };
+    /*  Listeners run in registration order. */
+    doc.listeners[0](ev);
+    doc.listeners[1](ev);
+
+    /*  Only panel_b (the topmost) should have grabbed focus. */
+    assert.deepEqual(panel_a_first.focus_calls, []);
+    assert.deepEqual(panel_b_first.focus_calls, ["b-first.focus"]);
+});
+
+test("LIFO stacking: releasing the top trap re-empowers the one underneath", () => {
+    let panel_a_first = make_focusable("a-first");
+    let panel_a = make_panel([panel_a_first]);
+    let panel_b_first = make_focusable("b-first");
+    let panel_b = make_panel([panel_b_first]);
+
+    let doc = make_doc(null);
+    activate_focus_trap_on(panel_a, doc);
+    let release_b = activate_focus_trap_on(panel_b, doc);
+
+    release_b();
+    assert.equal(doc.listeners.length, 1);
+
+    /*  Now Tab should drive panel_a — it is again the top. */
+    panel_a_first.focus_calls.length = 0;
+    doc.activeElement = make_focusable("outside");
+    let ev = {
+        key: "Tab",
+        shiftKey: false,
+        preventDefault() {}
+    };
+    doc.listeners[0](ev);
+    assert.deepEqual(panel_a_first.focus_calls, ["a-first.focus"]);
+});
+
 test("an empty panel installs the listener but does nothing on Tab", () => {
     let panel = make_panel([]);
     let doc   = make_doc(null);


### PR DESCRIPTION
## Summary

Closes the original review scope on the new declarative app shell.  Twelve commits, ~3.4k lines net, no production-code regressions on the legacy stack — `C_YUI_MAIN` / `C_YUI_ROUTING` are untouched.

What lands:

- **#3 Escape priority chain.** Single LIFO stack (`priv.escape_stack`) of `{layer, handler}` records.  Drawer, modal and any future overlay push themselves on open and pop on close; Escape calls only the top entry.  Public API `yui_shell_push_escape` / `yui_shell_pop_escape`.  Side effect: closes the focus-trap leak the drawer had on backdrop click.

- **#4 Modal/notification API.**  Seven helpers (`yui_shell_show_info` / `_warning` / `_error` / `_modal` for non-blocking; `yui_shell_confirm_ok` / `_yesno` / `_yesnocancel` for blocking dialogs that resolve a Promise).  Bulma `.notification` / `.modal-card` markup verbatim.  Each modal registers itself on the Escape stack and installs a focus-trap on the modal card.  Generic focus-trap moved to `src/shell_focus_trap.js` with 10 unit tests using hand-rolled DOM stubs.

- **#5 Generalised secondary-nav loop.** `instantiate_menus` walks every menu mounted via a \`menu.<id>\` host whose items declare a \`submenu\` (not just \`menu.primary\`).  Synthesised \`secondary.<owning_menu_id>.<item.id>\` keeps cross-menu items with the same id from colliding.

- **#6 Playwright e2e harness.**  22 specs × **3 browsers** (chromium + firefox + webkit) = **69 tests**.  Covers boot, navigation, drawer, modals, multimenu, validator, lifecycle, breakpoint, live-i18n.  CI workflow `.github/workflows/lib-yui.yml` runs unit + e2e on PRs touching \`kernel/js/lib-yui/**\` or \`kernel/js/gobj-js/**\`, uploads the Playwright HTML report on failure.

- **Validator follow-ups (review nits).**  \`validate_config\` now checks zone-host syntax (\`toolbar | menu.<id> | stage.<id>\`), stage-zone declaration, and cross-menu route-target uniqueness.  Includes a regression e2e spec that boots a deliberately-broken preset.

- **Modal/toast translation.**  Helpers tag every translatable text node with \`data-i18n=\"<canonical key>\"\`; new optional \`opts.t\` lets callers render in the active language at open time.  Test-app's \`Hello\` / \`Ask\` buttons now translate end-to-end.

- **Docs + CHANGELOG.**  \`SHELL.md\` §11 (Escape chain) + §6 modal/i18n subsections + secondary-nav menu_id explanation; \`TODO.md\` reflects every item closed; \`CHANGELOG.md\` Unreleased entry summarises the whole arc; \`install-e2e-deps.sh\` helper for local WebKit setup; \`CLAUDE.md\` + \`docs/doc.yuneta.io/installation.md\` updated with the optional dev-tooling nota.

Out of scope, kept under \`## Unreleased\` per request: the actual version bump (package.json stays at 7.3.0 until you cut the release).

## Commits (12)

\`741005a12\` audit + validation hardening (validator + audit witness + no-silent-catch)
\`e2a7e1404\` validator toolbar shape + EV_NAVIGATION_REQUESTED → EV_ROUTE_REQUESTED rename + docs
\`8df93ae3d\` Playwright harness — boot + navigation specs
\`6e7d87d6d\` Escape priority chain (TODO #3)
\`8d252142c\` Modal/notification API (TODO #4)
\`037874d6b\` Generalise secondary-nav loop (TODO #5)
\`ea0cd1060\` validate_config follow-ups (host syntax, stage-zone declaration, route uniqueness)
\`1bdf1593e\` lifecycle + breakpoint + live-i18n e2e specs
\`57e4b99ea\` translate Hello/Ask toolbar buttons + lock with e2e
\`c30436313\` translate modals/toasts via opts.t + data-i18n tags
\`66a37e103\` CHANGELOG Unreleased entry
\`c540faaa3\` add webkit to the Playwright matrix

## Test plan

- [ ] \`cd kernel/js/lib-yui && npm test\` — 23/23 (parser + focus-trap)
- [ ] \`./install-e2e-deps.sh\` once on a clean machine, then \`npm run test:e2e\` — 69/69
- [ ] \`npm run dev\` in test-app:
    - [ ] Default preset: ES/EN button flips menu / submenu / toolbar / Hello / Ask labels
    - [ ] Click \`Hello\` → toast appears in current language; \`Ask\` → dialog with Yes/No translated; click Yes → follow-up toast
    - [ ] Drawer opens from burger; Escape closes drawer; focus returns to burger
    - [ ] Open drawer, then open Ask via toolbar (or programmatically) → first Escape closes the modal, second Escape closes the drawer
    - [ ] Visit \`/dash/alerts\` (lazy_destroy) twice → instance # increments; \`/dash/ov\` (keep_alive) keeps the same number
    - [ ] \`?preset=multimenu\` shows two primary-style menus side-by-side; navigating to \`/admin/dash/users\` flips the active secondary nav
    - [ ] \`?preset=invalid\` shows the danger banner with \`invalid config\` text and console errors

## Acknowledged debt

- focus-trap unit tests use hand-rolled DOM stubs (instead of jsdom).  Switch to jsdom / happy-dom only if a real edge case (Shadow DOM, \`inert\`, native \`<dialog>\`, …) appears.  Tracked in \`TODO.md\` §6 \"Acknowledged debt\".
- Version bump postponed: package.json is still 7.3.0; CHANGELOG entry sits under \`## Unreleased\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)