### PR TITLE
Migrate auth to standard OIDC discovery + explicit endpoint override

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,96 @@
+# TODO
+
+Tracks API renames, removals and additions between versions.
+
+## Auth: complete OIDC migration
+
+The `c_auth_bff` (BFF) and `c_task_authenticate` (ROPC task) gclasses
+were migrated from a Keycloak-only path scheme to standard OIDC
+discovery + explicit endpoint override (commits `b916096`, `1e9a543`).
+Items below close out the migration.
+
+### Deprecated, scheduled for removal
+
+Targeted for removal once all callers are migrated and one release
+has shipped with the deprecation warning in place.
+
+- **`c_auth_bff` attrs `idp_url` and `realm`** — replaced by `issuer`
+  (with discovery) or `token_endpoint`+`end_session_endpoint`
+  (explicit). `mt_create` already emits a warning when these are
+  used. Production batch `auth_bff.1801.json` already migrated to
+  `issuer`.
+
+- **`c_task_authenticate` attr `auth_url`** — replaced by `issuer`
+  or explicit endpoints. `mt_start` already emits a warning. Six
+  callers below still set this attr.
+
+- **`c_task_authenticate` attr `auth_system`** — was a no-op since
+  at least 2024 (the `SWITCHS` body falls through identically for
+  any value). Kept only for back-compat of the six callers below.
+
+### Callers to migrate
+
+Six gclasses still pass `auth_url`+`auth_system` to
+`C_TASK_AUTHENTICATE` from CLI args / batch JSON. Each needs a new
+`--issuer` (and/or `--token-endpoint` / `--end-session-endpoint`)
+option, the existing `--auth-url` flag wired to the legacy attr,
+and a deprecation note in the help text.
+
+- `yunos/c/yuno_cli/src/c_cli.c` (lines 280–281, 1723–1785)
+- `yunos/c/mqtt_tui/src/c_mqtt_tui.c` (lines 177–178, 447–449, 913–914)
+- `utils/c/ycommand/src/c_ycommand.c` (lines 211–212, 428–430, 748–749)
+- `utils/c/ystats/src/c_ystats.c` (lines 48–49, 141–143, 185–186)
+- `utils/c/ytests/src/c_ytests.c` (lines 60–61, 170–172, 222–223)
+- `utils/c/ybatch/src/c_ybatch.c` (lines 61–62, 167–169, 219–220)
+
+### Test coverage gaps
+
+- **No tests for `c_task_authenticate`.** No unit tests at all
+  exist under `tests/c/c_task_authenticate/`. A mock-IdP harness
+  similar to `tests/c/c_auth_bff/c_mock_keycloak.c` would let us
+  exercise the discovery + token + logout chain, the legacy
+  `auth_url` deprecation warning, and the
+  `result_save_discovery` failure path that publishes
+  `EV_ON_TOKEN` with result=-1.
+
+- **No regression test for the BFF legacy path.** Tests 1–7 and
+  10 use `issuer`; 8/9/11/12 use explicit endpoints. The
+  `idp_url`+`realm` deprecation warning emitted by `mt_create`
+  is not covered by any test. A 17th test that sets the legacy
+  attrs and asserts the warning fires (and the flow still
+  works) would close this gap before the attrs are removed.
+
+### Smoke tests against real IdPs
+
+Mocked tests cover the wire format; they do not cover quirks of
+real IdP discovery documents.
+
+- **Keycloak** — redeploy `auth_bff.1801.json` (already migrated
+  to `issuer`) and verify login / refresh / logout work end-to-end
+  against a real Keycloak realm.
+
+- **Auth0 / Cognito / Authentik** — discovery document layouts
+  differ subtly (Auth0 uses `/oauth/token`, Cognito uses
+  `/oauth2/token`, Authentik uses `/application/o/token/`).
+  Configure a test BFF against each and confirm the discovery
+  response is parsed correctly and the follow-up token call
+  succeeds. ROPC (`grant_type=password`) is **not** supported
+  on most modern tenants of these IdPs by default — the BFF
+  `/auth/callback` PKCE flow is the path that actually works
+  cross-IdP; `c_task_authenticate` will fail there until ROPC
+  is replaced (see below).
+
+### Independent of OIDC migration
+
+- **Replace ROPC in `c_task_authenticate`** — the task posts
+  `grant_type=password` against the token endpoint. Discovery
+  fixes the URL but does not fix the grant: Auth0, Cognito,
+  Azure AD and Authentik either disable ROPC by default or
+  refuse it for confidential clients. Migrating to PKCE
+  (authorization code + code_verifier) would make the task
+  work against any modern IdP, at the cost of needing a
+  browser redirect — viable for `yuno_cli` and `ycommand`
+  (which already prompt the user) but not for headless
+  callers like `ybatch` / `ystats` / `ytests`.  Out of scope
+  for the current migration; flagged here so it surfaces when
+  the ROPC failure mode hits the first non-Keycloak deployment.

--- a/kernel/c/root-linux/src/c_auth_bff.c
+++ b/kernel/c/root-linux/src/c_auth_bff.c
@@ -180,8 +180,11 @@ SDATA_END()
  *---------------------------------------------*/
 PRIVATE sdata_desc_t attrs_table[] = {
 /*-ATTR-type------------name--------------------flag----default-description*/
-SDATA (DTP_STRING,      "idp_url",         SDF_RD|SDF_REQUIRED, "", "IdP base URL"),
-SDATA (DTP_STRING,      "realm",                SDF_RD|SDF_REQUIRED, "", "IdP realm"),
+SDATA (DTP_STRING,      "issuer",               SDF_RD, "",     "OIDC issuer URL (e.g. https://auth.example.com/realms/foo/). Triggers discovery via /.well-known/openid-configuration"),
+SDATA (DTP_STRING,      "token_endpoint",       SDF_RD, "",     "Explicit OAuth2 token endpoint URL. Overrides discovery"),
+SDATA (DTP_STRING,      "end_session_endpoint", SDF_RD, "",     "Explicit OIDC end_session endpoint URL. Overrides discovery"),
+SDATA (DTP_STRING,      "idp_url",              SDF_RD, "",     "DEPRECATED: use 'issuer' or explicit endpoints. IdP base URL (Keycloak path scheme)"),
+SDATA (DTP_STRING,      "realm",                SDF_RD, "",     "DEPRECATED: use 'issuer' or explicit endpoints. IdP realm (Keycloak-only)"),
 SDATA (DTP_STRING,      "client_id",            SDF_RD, "",     "IdP client_id (resource)"),
 SDATA (DTP_STRING,      "client_secret",        SDF_RD, "",     "Client secret (leave empty for public clients with PKCE)"),
 SDATA (DTP_STRING,      "cookie_domain",        SDF_RD, "",     "Cookie Domain attribute (shared hostname without port)"),
@@ -248,11 +251,19 @@ typedef struct _PRIVATE_DATA {
      */
     BOOL            task_valid;
 
-    /* Parsed IdP token endpoint URL parts */
-    char schema[32];
-    char host[256];
-    char port[16];
-    char path[1024];
+    /*
+     *  OIDC endpoints (full URLs).  Resolved in mt_create from one of:
+     *    1. Explicit token_endpoint + end_session_endpoint attrs
+     *    2. OIDC discovery (<issuer>/.well-known/openid-configuration)
+     *    3. Legacy idp_url + realm (Keycloak path scheme — deprecated)
+     *  process_next gates on discovery_done so requests queue while
+     *  discovery is in flight.
+     */
+    char    issuer[512];                /* copy of attr; "" if not configured */
+    char    token_url[PATH_MAX];        /* full URL — empty until discovery resolves it */
+    char    end_session_url[PATH_MAX];  /* full URL — empty until discovery resolves it */
+    BOOL    discovery_done;             /* TRUE once endpoints are usable */
+    hgobj   gobj_discovery_task;        /* one-shot OIDC discovery task; NULL when idle */
 
     /*
      *  Statistics — plain counters in PRIVATE_DATA, NOT SDF_*STATS
@@ -314,44 +325,72 @@ PRIVATE void mt_create(hgobj gobj)
      */
     snprintf(priv->idp_name, sizeof(priv->idp_name), "%s-idp", gobj_name(gobj));
 
-    /* Pre-parse IdProvider base URL for re-use in every outbound call */
-    char idp_base[PATH_MAX];
-    const char *idp_base_url  = gobj_read_str_attr(gobj, "idp_url");
-    const char *realm   = gobj_read_str_attr(gobj, "realm");
+    /*
+     *  OIDC endpoint resolution priority:
+     *    1. Explicit token_endpoint + end_session_endpoint    -> use directly
+     *    2. issuer                                            -> discover at startup
+     *    3. Legacy idp_url + realm (Keycloak path scheme)     -> deprecated, warn
+     *    4. None                                              -> error, BFF unusable
+     *
+     *  http_url is the URL passed to C_PROT_HTTP_CL/C_TCP for the
+     *  outbound connection (only host/port matter; the path of each
+     *  request is set per-call via the `resource` field).
+     */
+    const char *token_endpoint       = gobj_read_str_attr(gobj, "token_endpoint");
+    const char *end_session_endpoint = gobj_read_str_attr(gobj, "end_session_endpoint");
+    const char *issuer               = gobj_read_str_attr(gobj, "issuer");
+    const char *idp_base_url         = gobj_read_str_attr(gobj, "idp_url");
+    const char *realm                = gobj_read_str_attr(gobj, "realm");
 
-    build_path(idp_base, sizeof(idp_base),
-        idp_base_url,
-        "realms",
-        realm,
-        "protocol",
-        "openid-connect",
-        NULL
-    );
+    const char *http_url = NULL;
 
-    if(parse_url(gobj,
-        idp_base,
-        priv->schema, sizeof(priv->schema),
-        priv->host,   sizeof(priv->host),
-        priv->port,   sizeof(priv->port),
-        priv->path,   sizeof(priv->path),   // HACK important
-        NULL, 0,
-        FALSE
-    )<0) {
-        gobj_log_error(gobj, LOG_OPT_TRACE_STACK,
+    if(!empty_string(token_endpoint) && !empty_string(end_session_endpoint)) {
+        snprintf(priv->token_url, sizeof(priv->token_url), "%s",
+            token_endpoint);
+        snprintf(priv->end_session_url, sizeof(priv->end_session_url), "%s",
+            end_session_endpoint);
+        priv->discovery_done = TRUE;
+        http_url = token_endpoint;
+    } else if(!empty_string(issuer)) {
+        snprintf(priv->issuer, sizeof(priv->issuer), "%s", issuer);
+        priv->discovery_done = FALSE;
+        http_url = issuer;
+    } else if(!empty_string(idp_base_url) && !empty_string(realm)) {
+        char legacy_base[PATH_MAX];
+        build_path(legacy_base, sizeof(legacy_base),
+            idp_base_url, "realms", realm, "protocol", "openid-connect", NULL);
+        snprintf(priv->token_url, sizeof(priv->token_url),
+            "%s/token", legacy_base);
+        snprintf(priv->end_session_url, sizeof(priv->end_session_url),
+            "%s/logout", legacy_base);
+        priv->discovery_done = TRUE;
+        http_url = idp_base_url;
+        gobj_log_warning(gobj, 0,
             "function", "%s", __FUNCTION__,
-            "msgset",   "%s", MSGSET_SYSTEM,
-            "msg",      "%s", "idp url parse failed",
-            "url",      "%s", idp_base,
+            "msgset",   "%s", MSGSET_PARAMETER,
+            "msg",      "%s", "👤BFF idp_url+realm are deprecated; use 'issuer' or explicit endpoints",
+            "idp_url",  "%s", idp_base_url,
+            "realm",    "%s", realm,
             NULL
         );
     } else {
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_PARAMETER,
+            "msg",      "%s", "👤BFF no IdP configured: set 'issuer' or 'token_endpoint'+'end_session_endpoint'",
+            NULL
+        );
+        priv->discovery_done = FALSE;
+    }
+
+    if(http_url) {
         json_t *jn_crypto = gobj_read_json_attr(gobj, "crypto");
 
         priv->gobj_idprovider = gobj_create(
             priv->idp_name,
             C_PROT_HTTP_CL,
             json_pack("{s:s}",
-                "url", idp_base_url
+                "url", http_url
             ),
             gobj
         );
@@ -366,7 +405,7 @@ PRIVATE void mt_create(hgobj gobj)
                 priv->idp_name,
                 C_TCP,
                 json_pack("{s:s, s:O, s:i}",
-                    "url", idp_base_url,
+                    "url", http_url,
                     "crypto", jn_crypto,
                     /*
                      *  Aggressive reconnect cadence (100 ms vs the 2 s default).
@@ -405,6 +444,51 @@ PRIVATE void mt_destroy(hgobj gobj)
  ***************************************************************************/
 PRIVATE int mt_start(hgobj gobj)
 {
+    PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    /*
+     *  If `issuer` was configured (and the operator did not override
+     *  the endpoints explicitly), fetch /.well-known/openid-configuration
+     *  before serving any browser request.  Browser requests that arrive
+     *  before discovery completes queue in dl_pending; process_next gates
+     *  on priv->discovery_done so they're held until the endpoints are
+     *  cached.
+     */
+    if(!priv->discovery_done && !empty_string(priv->issuer) && priv->gobj_idprovider) {
+        json_int_t idp_timeout_ms = gobj_read_integer_attr(gobj, "idp_timeout_ms");
+        if(idp_timeout_ms <= 0) {
+            idp_timeout_ms = 30000;
+        }
+
+        json_t *kw_task = json_pack(
+            "{s:o, s:o, s:o, s:["
+                "{s:s, s:s, s:I}"
+            "]}",
+            "gobj_jobs",    json_integer((json_int_t)(uintptr_t)gobj),
+            "gobj_results", json_integer((json_int_t)(uintptr_t)priv->gobj_idprovider),
+            "output_data",  json_object(),
+            "jobs",
+                "exec_action",  "discover_oidc",
+                "exec_result",  "save_oidc_discovery",
+                "exec_timeout", idp_timeout_ms
+        );
+
+        priv->gobj_discovery_task = gobj_create(
+            priv->idp_name, C_TASK, kw_task, gobj);
+        gobj_subscribe_event(priv->gobj_discovery_task, EV_END_TASK, NULL, gobj);
+        gobj_set_volatil(priv->gobj_discovery_task, TRUE);
+
+        gobj_start(priv->gobj_discovery_task);
+        if(!gobj_is_running(priv->gobj_idprovider)) {
+            gobj_start(priv->gobj_idprovider);
+        }
+
+        if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
+            gobj_trace_msg(gobj,
+                "👤BFF OIDC discovery started: issuer=%s",
+                priv->issuer);
+        }
+    }
     return 0;
 }
 
@@ -414,6 +498,11 @@ PRIVATE int mt_start(hgobj gobj)
 PRIVATE int mt_stop(hgobj gobj)
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    if(priv->gobj_discovery_task && gobj_is_running(priv->gobj_discovery_task)) {
+        gobj_stop(priv->gobj_discovery_task);
+    }
+    priv->gobj_discovery_task = NULL;
 
     if(priv->gobj_task && gobj_is_running(priv->gobj_task)) {
         gobj_stop(priv->gobj_task);
@@ -563,15 +652,19 @@ PRIVATE json_t *cmd_view_status(hgobj gobj, const char *cmd, json_t *kw, hgobj s
         json_array_append_new(jn_queue, jn_entry);
     }
 
-    json_t *jn_data = json_pack("{s:s, s:s, s:b, s:b, s:s, s:I, s:i, s:o}",
-        "name",             gobj_name(gobj),
-        "full_name",        gobj_short_name(gobj),
-        "processing",       priv->processing ? 1 : 0,
-        "has_active_http",  priv->gobj_idprovider ? 1 : 0,
-        "active_http",      priv->gobj_idprovider ? gobj_short_name(priv->gobj_idprovider) : "",
-        "q_count",          (json_int_t)dl_size(&priv->dl_pending),
-        "q_max",            priv->queue_size_max,
-        "queue",            jn_queue
+    json_t *jn_data = json_pack("{s:s, s:s, s:b, s:b, s:s, s:I, s:i, s:o, s:b, s:s, s:s, s:s}",
+        "name",                 gobj_name(gobj),
+        "full_name",            gobj_short_name(gobj),
+        "processing",           priv->processing ? 1 : 0,
+        "has_active_http",      priv->gobj_idprovider ? 1 : 0,
+        "active_http",          priv->gobj_idprovider ? gobj_short_name(priv->gobj_idprovider) : "",
+        "q_count",              (json_int_t)dl_size(&priv->dl_pending),
+        "q_max",                priv->queue_size_max,
+        "queue",                jn_queue,
+        "discovery_done",       priv->discovery_done ? 1 : 0,
+        "issuer",               priv->issuer,
+        "token_endpoint",       priv->token_url,
+        "end_session_endpoint", priv->end_session_url
     );
 
     return msg_iev_build_response(
@@ -1305,7 +1398,27 @@ PRIVATE json_t *get_token_from_idp(
         gobj, output_data, "_action", 0, KW_REQUIRED);
 
     char resource[PATH_MAX];
-    build_path(resource, sizeof(resource), priv->path, "token", NULL);
+    {
+        char ep_schema[32], ep_host[256], ep_port[16];
+        if(parse_url(gobj,
+                priv->token_url,
+                ep_schema, sizeof(ep_schema),
+                ep_host,   sizeof(ep_host),
+                ep_port,   sizeof(ep_port),
+                resource,  sizeof(resource),
+                NULL, 0,
+                FALSE) < 0) {
+            gobj_log_error(gobj, 0,
+                "function",  "%s", __FUNCTION__,
+                "msgset",    "%s", MSGSET_PROTOCOL,
+                "msg",       "%s", "👤BFF invalid token_endpoint URL",
+                "token_url", "%s", priv->token_url,
+                NULL
+            );
+            KW_DECREF(kw)
+            STOP_TASK()
+        }
+    }
 
     json_t *jn_headers = json_pack("{s:s}",
         "Content-Type", "application/x-www-form-urlencoded"
@@ -1405,7 +1518,27 @@ PRIVATE json_t *get_logout_from_idp(
     const char *cs        = gobj_read_str_attr(gobj, "client_secret");
 
     char resource[PATH_MAX];
-    build_path(resource, sizeof(resource), priv->path, "logout", NULL);
+    {
+        char ep_schema[32], ep_host[256], ep_port[16];
+        if(parse_url(gobj,
+                priv->end_session_url,
+                ep_schema, sizeof(ep_schema),
+                ep_host,   sizeof(ep_host),
+                ep_port,   sizeof(ep_port),
+                resource,  sizeof(resource),
+                NULL, 0,
+                FALSE) < 0) {
+            gobj_log_error(gobj, 0,
+                "function",        "%s", __FUNCTION__,
+                "msgset",          "%s", MSGSET_PROTOCOL,
+                "msg",             "%s", "👤BFF invalid end_session_endpoint URL",
+                "end_session_url", "%s", priv->end_session_url,
+                NULL
+            );
+            KW_DECREF(kw)
+            STOP_TASK()
+        }
+    }
 
     json_t *jn_headers = json_pack("{s:s}", "Content-Type",
         "application/x-www-form-urlencoded");
@@ -1538,6 +1671,124 @@ PRIVATE json_t *send_logout_to_browser(
 }
 
 /***************************************************************************
+ *  OIDC discovery: GET <issuer>/.well-known/openid-configuration.
+ *  Action job of the discovery task fired in mt_start.
+ ***************************************************************************/
+PRIVATE json_t *discover_oidc(
+    hgobj gobj,
+    const char *lmethod,
+    json_t *kw,
+    hgobj src_task
+)
+{
+    PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    char ep_schema[32], ep_host[256], ep_port[16], ep_path[1024];
+    if(parse_url(gobj,
+            priv->issuer,
+            ep_schema, sizeof(ep_schema),
+            ep_host,   sizeof(ep_host),
+            ep_port,   sizeof(ep_port),
+            ep_path,   sizeof(ep_path),
+            NULL, 0,
+            FALSE) < 0) {
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_PROTOCOL,
+            "msg",      "%s", "👤BFF discovery: invalid issuer URL",
+            "issuer",   "%s", priv->issuer,
+            NULL
+        );
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    char resource[PATH_MAX];
+    build_path(resource, sizeof(resource),
+        ep_path, ".well-known", "openid-configuration", NULL);
+
+    json_t *jn_headers = json_pack("{s:s}",
+        "Accept", "application/json"
+    );
+    json_t *query = json_pack("{s:s, s:s, s:s, s:o, s:o}",
+        "method",   "GET",
+        "resource", resource,
+        "query",    "",
+        "headers",  jn_headers,
+        "data",     json_object()
+    );
+
+    if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
+        gobj_trace_msg(gobj, "👤BFF ⏩ discovery: GET %s", resource);
+    }
+
+    gobj_send_event(priv->gobj_idprovider, EV_SEND_MESSAGE, query, gobj);
+
+    KW_DECREF(kw)
+    CONTINUE_TASK()
+}
+
+/***************************************************************************
+ *  OIDC discovery: parse response body, cache token_endpoint and
+ *  end_session_endpoint, drain pending requests via process_next.
+ ***************************************************************************/
+PRIVATE json_t *save_oidc_discovery(
+    hgobj gobj,
+    const char *lmethod,
+    json_t *kw,
+    hgobj src_task
+)
+{
+    PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    int status = (int)kw_get_int(gobj, kw, "response_status_code", -1, 0);
+    if(status != 200) {
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_PROTOCOL,
+            "msg",      "%s", "👤BFF OIDC discovery failed",
+            "status",   "%d", status,
+            "issuer",   "%s", priv->issuer,
+            NULL
+        );
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    json_t *jn_body = kw_get_dict(gobj, kw, "body", NULL, 0);
+    const char *token_ep = jn_body ?
+        kw_get_str(gobj, jn_body, "token_endpoint", "", 0) : "";
+    const char *end_session_ep = jn_body ?
+        kw_get_str(gobj, jn_body, "end_session_endpoint", "", 0) : "";
+
+    if(empty_string(token_ep) || empty_string(end_session_ep)) {
+        gobj_log_error(gobj, 0,
+            "function",             "%s", __FUNCTION__,
+            "msgset",               "%s", MSGSET_PROTOCOL,
+            "msg",                  "%s", "👤BFF OIDC discovery: missing required endpoints in response",
+            "token_endpoint",       "%s", token_ep,
+            "end_session_endpoint", "%s", end_session_ep,
+            NULL
+        );
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    snprintf(priv->token_url, sizeof(priv->token_url), "%s", token_ep);
+    snprintf(priv->end_session_url, sizeof(priv->end_session_url), "%s", end_session_ep);
+    priv->discovery_done = TRUE;
+
+    if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
+        gobj_trace_msg(gobj,
+            "👤BFF ⏪ discovery OK: token=%s end_session=%s",
+            priv->token_url, priv->end_session_url);
+    }
+
+    KW_DECREF(kw)
+    CONTINUE_TASK()
+}
+
+/***************************************************************************
  *  Start processing the next pending auth request.
  ***************************************************************************/
 PRIVATE void process_next(hgobj gobj)
@@ -1545,6 +1796,14 @@ PRIVATE void process_next(hgobj gobj)
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
     if(priv->processing || dl_size(&priv->dl_pending) == 0) {
+        return;
+    }
+    if(!priv->discovery_done) {
+        /*
+         *  OIDC endpoints not yet resolved (discovery in flight or no
+         *  IdP configured).  Keep requests queued; this function will
+         *  be re-driven from ac_end_task once discovery completes.
+         */
         return;
     }
 
@@ -1556,25 +1815,15 @@ PRIVATE void process_next(hgobj gobj)
     priv->processing = TRUE;
     priv->task_valid = TRUE;
 
-    /* Build IdP URL from parsed parts */
-    char idp_token_url[PATH_MAX * 2];
-    char idp_token_path[PATH_MAX];
-    build_path(idp_token_path, sizeof(idp_token_path), priv->path, "token", NULL);
-    snprintf(idp_token_url, sizeof(idp_token_url),
-        "%s://%s%s%s%s",
-        priv->schema,
-        priv->host,
-        empty_string(priv->port) ? "" : ":",
-        empty_string(priv->port) ? "" : priv->port,
-        idp_token_path
-    );
+    const char *target_url =
+        (pa->action == BFF_LOGOUT) ? priv->end_session_url : priv->token_url;
 
     priv->st_idp_calls++;
 
     if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
         gobj_trace_msg(gobj,
             "👤BFF ⏩ IdP: action=%s url=%s queue_after=%d",
-            action_name(pa->action), idp_token_url, (int)dl_size(&priv->dl_pending)
+            action_name(pa->action), target_url, (int)dl_size(&priv->dl_pending)
         );
     }
 
@@ -2024,6 +2273,27 @@ PRIVATE int ac_end_task(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
 {
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
+    /*
+     *  Discovery task ends separately from the auth tasks: it never
+     *  has a browser waiting, doesn't move the idp_* counters, and
+     *  must drain the pending queue once the endpoints are cached.
+     */
+    if(src == priv->gobj_discovery_task) {
+        priv->gobj_discovery_task = NULL;  /* ac_stopped will destroy it */
+        int discovery_result = (int)kw_get_int(gobj, kw, "result", 0, 0);
+        if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
+            gobj_trace_msg(gobj,
+                "👤BFF discovery task ended (result=%d, discovery_done=%d)",
+                discovery_result, priv->discovery_done ? 1 : 0
+            );
+        }
+        KW_DECREF(kw)
+        if(priv->discovery_done) {
+            process_next(gobj);
+        }
+        return 0;
+    }
+
     priv->gobj_task = NULL;  /* ac_stopped will destroy it */
     priv->processing = FALSE;
 
@@ -2109,6 +2379,8 @@ PRIVATE const GMETHODS gmt = {
 };
 
 PRIVATE LMETHOD lmt[] = {
+    {"discover_oidc",           discover_oidc,          0},
+    {"save_oidc_discovery",     save_oidc_discovery,    0},
     {"get_token_from_idp",      get_token_from_idp,     0},
     {"send_token_to_browser",   send_token_to_browser,  0},
     {"get_logout_from_idp",     get_logout_from_idp,    0},

--- a/kernel/c/root-linux/src/c_auth_bff.h
+++ b/kernel/c/root-linux/src/c_auth_bff.h
@@ -13,6 +13,25 @@
  *  httpOnly; Secure; SameSite=Strict cookies so the browser forwards
  *  them automatically with every WebSocket HTTP Upgrade to port 1800.
  *
+ *  IdP configuration (priority order):
+ *
+ *    1. Explicit endpoints — set both `token_endpoint` and
+ *       `end_session_endpoint` to the full URLs.  Skips discovery.
+ *
+ *    2. OIDC discovery — set `issuer` to the IdP issuer URL
+ *       (e.g. https://auth.example.com/realms/foo/).  At mt_start the
+ *       BFF GETs <issuer>/.well-known/openid-configuration and caches
+ *       the resolved endpoints.  Standard OIDC, IdP-agnostic.
+ *
+ *    3. Legacy Keycloak path scheme — `idp_url` + `realm` (DEPRECATED).
+ *       Builds <idp_url>/realms/<realm>/protocol/openid-connect/token
+ *       and .../logout.  Emits a warning at startup; will be removed
+ *       in a future release.  Migrate to (1) or (2).
+ *
+ *  The `iss` claim of every JWT validated by c_authz must match the
+ *  `issuer` value returned by the discovery document (or the issuer of
+ *  the IdP backing the explicit endpoints).
+ *
  *  Copyright (c) 2026, ArtGins.
  *  All Rights Reserved.
  ****************************************************************************/

--- a/kernel/c/root-linux/src/c_task_authenticate.c
+++ b/kernel/c/root-linux/src/c_task_authenticate.c
@@ -2,7 +2,26 @@
  *          c_task_authenticate.c
  *          Task_authenticate GClass.
  *
- *          Task to authenticate with OAuth2 against keycloak (WARNING by now only tested in keycloak)
+ *          Task to authenticate with OAuth2 against an OIDC IdP.
+ *
+ *  IdP configuration (priority order — same scheme as c_auth_bff):
+ *
+ *    1. Explicit endpoints — set both 'token_endpoint' and
+ *       'end_session_endpoint' to the full URLs.  Skips discovery.
+ *
+ *    2. OIDC discovery — set 'issuer' to the IdP issuer URL
+ *       (e.g. https://auth.example.com/realms/foo/).  At mt_start the
+ *       task chain prepends a discovery GET of
+ *       <issuer>/.well-known/openid-configuration; resolved endpoints
+ *       are cached in priv before action_get_token runs.
+ *
+ *    3. Legacy 'auth_url' (DEPRECATED).  Builds
+ *       <auth_url>/protocol/openid-connect/{token,logout}.  Emits a
+ *       warning at startup; will be removed in a future release.
+ *
+ *  The 'auth_system' attr no longer routes flow selection (the
+ *  SWITCHS body falls through identically for any value).  It is
+ *  preserved for back-compat but documented as deprecated.
 
 Example of id_token
 -------------------
@@ -176,8 +195,11 @@ PRIVATE sdata_desc_t attrs_table[] = {
 /*-ATTR-type------------name----------------flag------------default---------description---------- */
 SDATA (DTP_BOOLEAN,     "offline_access",   SDF_RD,         0,              "Get offline token"),
 SDATA (DTP_JSON,        "crypto",           SDF_RD,         "{}",           "Crypto config"),
-SDATA (DTP_STRING,      "auth_system",      SDF_RD,         "keycloak",     "OpenID System(interactive jwt)"),
-SDATA (DTP_STRING,      "auth_url",         SDF_RD,         "",             "OpenID Endpoint (interactive jwt)"),
+SDATA (DTP_STRING,      "issuer",           SDF_RD,         "",             "OIDC issuer URL (e.g. https://auth.example.com/realms/foo/). Triggers discovery via /.well-known/openid-configuration"),
+SDATA (DTP_STRING,      "token_endpoint",   SDF_RD,         "",             "Explicit OAuth2 token endpoint URL. Overrides discovery"),
+SDATA (DTP_STRING,      "end_session_endpoint", SDF_RD,     "",             "Explicit OIDC end_session endpoint URL. Overrides discovery"),
+SDATA (DTP_STRING,      "auth_system",      SDF_RD,         "keycloak",     "DEPRECATED: no longer routes flow selection. Kept for back-compat"),
+SDATA (DTP_STRING,      "auth_url",         SDF_RD,         "",             "DEPRECATED: use 'issuer' or explicit endpoints. Legacy Keycloak base URL <auth_url>/protocol/openid-connect/{token,logout}"),
 SDATA (DTP_STRING,      "user_id",          SDF_RD,         "",             "OAuth2 User Id (interactive jwt)"),
 SDATA (DTP_STRING,      "user_passw",       0,              "",             "OAuth2 User Password (interactive jwt)"),
 SDATA (DTP_STRING,      "azp",              SDF_RD,         "",             "OAuth2 Authorized Party  (jwt's azp field - interactive jwt)"),
@@ -207,11 +229,18 @@ PRIVATE const trace_level_t s_user_trace_level[16] = {
  *              Private data
  *---------------------------------------------*/
 typedef struct _PRIVATE_DATA {
-    char schema[32];
-    char host[120];
-    char port[40];
-    char path[2*1024];
-    char query[4*1024];
+    /*
+     *  OIDC endpoints (full URLs).  Resolved in mt_start from one of:
+     *    1. Explicit token_endpoint + end_session_endpoint attrs
+     *    2. OIDC discovery (<issuer>/.well-known/openid-configuration)
+     *    3. Legacy auth_url (Keycloak path scheme — deprecated)
+     *  The discovery flow chains action_discover/result_save_discovery
+     *  in front of action_get_token in the C_TASK jobs array.
+     */
+    char    issuer[512];                 /* copy of attr; "" if not configured */
+    char    token_url[PATH_MAX];         /* full URL — empty until discovery resolves it */
+    char    end_session_url[PATH_MAX];   /* full URL — empty until discovery resolves it */
+    BOOL    discovery_done;              /* TRUE once endpoints are usable */
 
     hgobj gobj_http;
 } PRIVATE_DATA;
@@ -278,30 +307,72 @@ PRIVATE int mt_start(hgobj gobj)
     PRIVATE_DATA *priv = gobj_priv_data(gobj);
 
     /*-----------------------------*
-     *      Create http
+     *  OIDC endpoint resolution priority:
+     *    1. Explicit token_endpoint + end_session_endpoint    -> use directly
+     *    2. issuer                                            -> discover at startup
+     *    3. Legacy auth_url (Keycloak path scheme)            -> deprecated, warn
+     *    4. None                                              -> error, refuse to start
+     *
+     *  http_url is the URL passed to C_PROT_HTTP_CL/C_TCP for the
+     *  outbound connection (only host/port matter; the path of each
+     *  request is set per-call via the `resource` field).
      *-----------------------------*/
-    const char *auth_url = gobj_read_str_attr(gobj, "auth_url");
-    int r = parse_url(gobj,
-        auth_url,
-        priv->schema, sizeof(priv->schema),
-        priv->host, sizeof(priv->host),
-        priv->port, sizeof(priv->port),
-        priv->path, sizeof(priv->path),
-        priv->query, sizeof(priv->query),
-        FALSE
-    );
-    if(r < 0) {
-        gobj_log_error(gobj, 0,
-            "function",     "%s", __FUNCTION__,
-            "msgset",       "%s", MSGSET_TASK,
-            "msg",          "%s", "BAD url parsing",
-            "url",          "%s", auth_url,
+    const char *token_endpoint       = gobj_read_str_attr(gobj, "token_endpoint");
+    const char *end_session_endpoint = gobj_read_str_attr(gobj, "end_session_endpoint");
+    const char *issuer               = gobj_read_str_attr(gobj, "issuer");
+    const char *auth_url             = gobj_read_str_attr(gobj, "auth_url");
+
+    const char *http_url = NULL;
+
+    if(!empty_string(token_endpoint) && !empty_string(end_session_endpoint)) {
+        snprintf(priv->token_url, sizeof(priv->token_url), "%s",
+            token_endpoint);
+        snprintf(priv->end_session_url, sizeof(priv->end_session_url), "%s",
+            end_session_endpoint);
+        priv->discovery_done = TRUE;
+        http_url = token_endpoint;
+    } else if(!empty_string(issuer)) {
+        snprintf(priv->issuer, sizeof(priv->issuer), "%s", issuer);
+        priv->discovery_done = FALSE;
+        http_url = issuer;
+    } else if(!empty_string(auth_url)) {
+        /*
+         *  Legacy Keycloak path scheme.  Strip a trailing slash from
+         *  auth_url before composing so we don't end up with a double
+         *  slash in "<auth_url>//protocol/...".
+         */
+        size_t len = strlen(auth_url);
+        char base[PATH_MAX];
+        snprintf(base, sizeof(base), "%s", auth_url);
+        if(len > 0 && base[len-1] == '/') {
+            base[len-1] = 0;
+        }
+        snprintf(priv->token_url, sizeof(priv->token_url),
+            "%s/protocol/openid-connect/token", base);
+        snprintf(priv->end_session_url, sizeof(priv->end_session_url),
+            "%s/protocol/openid-connect/logout", base);
+        priv->discovery_done = TRUE;
+        http_url = auth_url;
+        gobj_log_warning(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_PARAMETER,
+            "msg",      "%s", "task_authenticate: 'auth_url' is deprecated; use 'issuer' or explicit endpoints",
+            "auth_url", "%s", auth_url,
             NULL
         );
+    } else {
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_PARAMETER,
+            "msg",      "%s", "task_authenticate: no IdP configured: set 'issuer' or 'token_endpoint'+'end_session_endpoint'",
+            NULL
+        );
+        return -1;
     }
-    if(strlen(priv->path) > 0 && priv->path[strlen(priv->path)-1]=='/') {
-        priv->path[strlen(priv->path)-1] = 0;
-    }
+
+    /*-----------------------------*
+     *      Create http
+     *-----------------------------*/
     json_t *jn_crypto = gobj_read_json_attr(gobj, "crypto");
 
     priv->gobj_http = gobj_create(
@@ -309,7 +380,7 @@ PRIVATE int mt_start(hgobj gobj)
         C_PROT_HTTP_CL,
         json_pack("{s:I, s:s}",
             "subscriber", (json_int_t)0,
-            "url", auth_url
+            "url", http_url
         ),
         gobj
     );
@@ -323,27 +394,41 @@ PRIVATE int mt_start(hgobj gobj)
        gobj_create_pure_child(
            gobj_name(gobj),
            C_TCP,
-           json_pack("{s:s, s:O}", "url", auth_url, "crypto", jn_crypto),
+           json_pack("{s:s, s:O}", "url", http_url, "crypto", jn_crypto),
            priv->gobj_http
        )
    );
 
     /*-----------------------------*
      *      Create the task
+     *
+     *  When discovery is needed, prepend [action_discover,
+     *  result_save_discovery] to the existing token/logout chain so
+     *  endpoints are resolved on the same connection before the auth
+     *  flow runs.
      *-----------------------------*/
+    json_t *jobs = json_array();
+    if(!priv->discovery_done) {
+        json_array_append_new(jobs, json_pack("{s:s, s:s}",
+            "exec_action", "action_discover",
+            "exec_result", "result_save_discovery"
+        ));
+    }
+    json_array_append_new(jobs, json_pack("{s:s, s:s}",
+        "exec_action", "action_get_token",
+        "exec_result", "result_get_token"
+    ));
+    json_array_append_new(jobs, json_pack("{s:s, s:s}",
+        "exec_action", "action_logout",
+        "exec_result", "result_logout"
+    ));
+
     json_t *kw_task = json_pack(
-        "{s:o, s:o, s:o, s:["
-            "{s:s, s:s},"
-            "{s:s, s:s}"
-        "]}",
-        "gobj_jobs", json_integer((json_int_t)(uintptr_t)gobj),
+        "{s:o, s:o, s:o, s:o}",
+        "gobj_jobs",    json_integer((json_int_t)(uintptr_t)gobj),
         "gobj_results", json_integer((json_int_t)(uintptr_t)priv->gobj_http),
-        "output_data", json_object(),
-        "jobs",
-            "exec_action", "action_get_token",
-            "exec_result", "result_get_token",
-            "exec_action", "action_logout",
-            "exec_result", "result_logout"
+        "output_data",  json_object(),
+        "jobs",         jobs
     );
 
     hgobj gobj_task = gobj_create(gobj_name(gobj), C_TASK, kw_task, gobj);
@@ -440,6 +525,126 @@ PRIVATE int publish_token(
 
 
 /***************************************************************************
+ *  OIDC discovery: GET <issuer>/.well-known/openid-configuration.
+ *  Prepended to the task chain when 'issuer' is configured and no
+ *  explicit endpoint override is provided.
+ ***************************************************************************/
+PRIVATE json_t *action_discover(
+    hgobj gobj,
+    const char *lmethod,
+    json_t *kw,
+    hgobj src // Source is the GCLASS_TASK
+)
+{
+    PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    char ep_schema[32], ep_host[256], ep_port[16], ep_path[1024];
+    if(parse_url(gobj,
+            priv->issuer,
+            ep_schema, sizeof(ep_schema),
+            ep_host,   sizeof(ep_host),
+            ep_port,   sizeof(ep_port),
+            ep_path,   sizeof(ep_path),
+            NULL, 0,
+            FALSE) < 0) {
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_TASK,
+            "msg",      "%s", "task_authenticate: invalid issuer URL",
+            "issuer",   "%s", priv->issuer,
+            NULL
+        );
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    char resource[PATH_MAX];
+    build_path(resource, sizeof(resource),
+        ep_path, ".well-known", "openid-configuration", NULL);
+
+    json_t *jn_headers = json_pack("{s:s}",
+        "Accept", "application/json"
+    );
+    json_t *query = json_pack("{s:s, s:s, s:s, s:o, s:o}",
+        "method",   "GET",
+        "resource", resource,
+        "query",    "",
+        "headers",  jn_headers,
+        "data",     json_object()
+    );
+
+    gobj_send_event(priv->gobj_http, EV_SEND_MESSAGE, query, gobj);
+
+    KW_DECREF(kw)
+    CONTINUE_TASK()
+}
+
+/***************************************************************************
+ *  OIDC discovery: parse the response body, cache token_endpoint and
+ *  end_session_endpoint in priv.  Failure publishes EV_ON_TOKEN with
+ *  result=-1 so the caller doesn't hang waiting for it.
+ ***************************************************************************/
+PRIVATE json_t *result_save_discovery(
+    hgobj gobj,
+    const char *lmethod,
+    json_t *kw,
+    hgobj src // Source is the GCLASS_TASK
+)
+{
+    PRIVATE_DATA *priv = gobj_priv_data(gobj);
+
+    json_t *output_data_ = gobj_read_json_attr(src, "output_data");
+    int status = (int)kw_get_int(gobj, kw, "response_status_code", -1, 0);
+    if(status != 200) {
+        json_object_set_new(output_data_, "comment",
+            json_sprintf("OIDC discovery failed: status=%d", status)
+        );
+        gobj_log_error(gobj, 0,
+            "function", "%s", __FUNCTION__,
+            "msgset",   "%s", MSGSET_TASK,
+            "msg",      "%s", "task_authenticate: OIDC discovery failed",
+            "status",   "%d", status,
+            "issuer",   "%s", priv->issuer,
+            NULL
+        );
+        publish_token(gobj, -1, output_data_);
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    json_t *jn_body = kw_get_dict(gobj, kw, "body", NULL, 0);
+    const char *token_ep = jn_body ?
+        kw_get_str(gobj, jn_body, "token_endpoint", "", 0) : "";
+    const char *end_session_ep = jn_body ?
+        kw_get_str(gobj, jn_body, "end_session_endpoint", "", 0) : "";
+
+    if(empty_string(token_ep) || empty_string(end_session_ep)) {
+        json_object_set_new(output_data_, "comment",
+            json_string("OIDC discovery: missing required endpoints in response")
+        );
+        gobj_log_error(gobj, 0,
+            "function",             "%s", __FUNCTION__,
+            "msgset",               "%s", MSGSET_TASK,
+            "msg",                  "%s", "task_authenticate: OIDC discovery missing endpoints",
+            "token_endpoint",       "%s", token_ep,
+            "end_session_endpoint", "%s", end_session_ep,
+            NULL
+        );
+        publish_token(gobj, -1, output_data_);
+        KW_DECREF(kw)
+        STOP_TASK()
+    }
+
+    snprintf(priv->token_url, sizeof(priv->token_url), "%s", token_ep);
+    snprintf(priv->end_session_url, sizeof(priv->end_session_url),
+        "%s", end_session_ep);
+    priv->discovery_done = TRUE;
+
+    KW_DECREF(kw)
+    CONTINUE_TASK()
+}
+
+/***************************************************************************
  *
  ***************************************************************************/
 PRIVATE json_t *action_get_token(
@@ -459,8 +664,27 @@ PRIVATE json_t *action_get_token(
     SWITCHS(auth_system) {
         CASES("keycloak")
         DEFAULTS
+        {
             char resource[PATH_MAX];
-            build_path(resource, sizeof(resource), priv->path, "protocol/openid-connect/token", NULL);
+            char ep_schema[32], ep_host[256], ep_port[16];
+            if(parse_url(gobj,
+                    priv->token_url,
+                    ep_schema, sizeof(ep_schema),
+                    ep_host,   sizeof(ep_host),
+                    ep_port,   sizeof(ep_port),
+                    resource,  sizeof(resource),
+                    NULL, 0,
+                    FALSE) < 0) {
+                gobj_log_error(gobj, 0,
+                    "function",  "%s", __FUNCTION__,
+                    "msgset",    "%s", MSGSET_TASK,
+                    "msg",       "%s", "task_authenticate: invalid token_endpoint URL",
+                    "token_url", "%s", priv->token_url,
+                    NULL
+                );
+                KW_DECREF(kw)
+                STOP_TASK()
+            }
 
             json_t *jn_headers = json_pack("{s:s}",
                 "Content-Type", "application/x-www-form-urlencoded"
@@ -485,6 +709,7 @@ PRIVATE json_t *action_get_token(
             );
             gobj_send_event(priv->gobj_http, EV_SEND_MESSAGE, query, gobj);
             break;
+        }
     } SWITCHS_END
 
     KW_DECREF(kw)
@@ -634,12 +859,27 @@ PRIVATE json_t *action_logout(
     SWITCHS(auth_system) {
         CASES("keycloak")
         DEFAULTS
+        {
             char resource[PATH_MAX];
-            snprintf(
-                resource, sizeof(resource),
-                "%s/protocol/openid-connect/logout",
-                priv->path
-            );
+            char ep_schema[32], ep_host[256], ep_port[16];
+            if(parse_url(gobj,
+                    priv->end_session_url,
+                    ep_schema, sizeof(ep_schema),
+                    ep_host,   sizeof(ep_host),
+                    ep_port,   sizeof(ep_port),
+                    resource,  sizeof(resource),
+                    NULL, 0,
+                    FALSE) < 0) {
+                gobj_log_error(gobj, 0,
+                    "function",        "%s", __FUNCTION__,
+                    "msgset",          "%s", MSGSET_TASK,
+                    "msg",             "%s", "task_authenticate: invalid end_session_endpoint URL",
+                    "end_session_url", "%s", priv->end_session_url,
+                    NULL
+                );
+                KW_DECREF(kw)
+                STOP_TASK()
+            }
 
             char authorization[1024];
             snprintf(authorization, sizeof(authorization), "Bearer %s", access_token);
@@ -664,6 +904,7 @@ PRIVATE json_t *action_logout(
             );
             gobj_send_event(priv->gobj_http, EV_SEND_MESSAGE, query, gobj);
             break;
+        }
     } SWITCHS_END
 
 
@@ -782,10 +1023,12 @@ PRIVATE const GMETHODS gmt = {
  *              Local methods table
  *---------------------------------------------*/
 PRIVATE LMETHOD lmt[] = {
-    {"action_get_token",            action_get_token,   0},
-    {"result_get_token",            result_get_token,   0},
-    {"action_logout",               action_logout,      0},
-    {"result_logout",               result_logout,      0},
+    {"action_discover",             action_discover,        0},
+    {"result_save_discovery",       result_save_discovery,  0},
+    {"action_get_token",            action_get_token,       0},
+    {"result_get_token",            result_get_token,       0},
+    {"action_logout",               action_logout,          0},
+    {"result_logout",               result_logout,          0},
     {0, 0, 0}
 };
 

--- a/kernel/c/root-linux/src/c_task_authenticate.h
+++ b/kernel/c/root-linux/src/c_task_authenticate.h
@@ -2,16 +2,26 @@
  *          c_task_authenticate.h
  *          Task_authenticate GClass.
  *
- *          Task to authenticate with OAuth2.
+ *  Task to authenticate against an OIDC IdP using OAuth2 ROPC
+ *  (Resource Owner Password Credentials).
  *
- *  NOTE — Keycloak coupling:
- *  This gclass currently assumes the Keycloak path scheme
- *      <auth_url>/protocol/openid-connect/{token,logout}
- *  (see c_task_authenticate.c, action_get_token / action_logout).
- *  OIDC discovery + IdP-agnostic operation will be added in a future
- *  commit, mirroring the issuer/.well-known approach used by
- *  c_auth_bff (see c_auth_bff.h).  Until then, only Keycloak-style
- *  IdPs are supported here.
+ *  IdP configuration (priority order — see c_task_authenticate.c):
+ *
+ *    1. Explicit 'token_endpoint' + 'end_session_endpoint' attrs
+ *       — full URLs, skips discovery.
+ *
+ *    2. 'issuer' attr — full issuer URL.  The task chain prepends
+ *       a GET of <issuer>/.well-known/openid-configuration before
+ *       action_get_token, caches the resolved endpoints in priv,
+ *       and continues the auth flow on the same connection.
+ *
+ *    3. Legacy 'auth_url' (DEPRECATED) — Keycloak path scheme.
+ *       Emits a startup warning; will be removed in a future
+ *       release.  Six callers still use this path:
+ *       yuno_cli, ybatch, ystats, ytests, ycommand, mqtt_tui.
+ *
+ *  The 'auth_system' attr is preserved for back-compat but no
+ *  longer routes flow selection.
  *
  *          Copyright (c) 2021 Niyamaka.
  *          Copyright (c) 2024, ArtGins.

--- a/kernel/c/root-linux/src/c_task_authenticate.h
+++ b/kernel/c/root-linux/src/c_task_authenticate.h
@@ -2,7 +2,16 @@
  *          c_task_authenticate.h
  *          Task_authenticate GClass.
  *
- *          Task to authenticate with OAuth2
+ *          Task to authenticate with OAuth2.
+ *
+ *  NOTE — Keycloak coupling:
+ *  This gclass currently assumes the Keycloak path scheme
+ *      <auth_url>/protocol/openid-connect/{token,logout}
+ *  (see c_task_authenticate.c, action_get_token / action_logout).
+ *  OIDC discovery + IdP-agnostic operation will be added in a future
+ *  commit, mirroring the issuer/.well-known approach used by
+ *  c_auth_bff (see c_auth_bff.h).  Until then, only Keycloak-style
+ *  IdPs are supported here.
  *
  *          Copyright (c) 2021 Niyamaka.
  *          Copyright (c) 2024, ArtGins.

--- a/performance/c/perf_auth_bff/main_perf_auth_bff.c
+++ b/performance/c/perf_auth_bff/main_perf_auth_bff.c
@@ -120,8 +120,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-(^^__range__^^)',          \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/stress/c/auth_bff/main_stress_auth_bff.c
+++ b/stress/c/auth_bff/main_stress_auth_bff.c
@@ -119,8 +119,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-(^^__range__^^)',          \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'keycloak_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/c_mock_keycloak.c
+++ b/tests/c/c_auth_bff/c_mock_keycloak.c
@@ -93,6 +93,7 @@ typedef struct _PRIVATE_DATA {
     uint64_t    st_responses_sent;
     uint64_t    st_token_requests;
     uint64_t    st_logout_requests;
+    uint64_t    st_discovery_requests;
     uint64_t    st_unknown_requests;
     uint64_t    st_deferred_responses;
     uint64_t    st_pending_cancelled;
@@ -209,16 +210,18 @@ PRIVATE json_t *mt_stats(hgobj gobj, const char *stats, json_t *kw, hgobj src)
         priv->st_responses_sent     = 0;
         priv->st_token_requests     = 0;
         priv->st_logout_requests    = 0;
+        priv->st_discovery_requests = 0;
         priv->st_unknown_requests   = 0;
         priv->st_deferred_responses = 0;
         priv->st_pending_cancelled  = 0;
     }
 
-    json_t *jn_data = json_pack("{s:I, s:I, s:I, s:I, s:I, s:I, s:I}",
+    json_t *jn_data = json_pack("{s:I, s:I, s:I, s:I, s:I, s:I, s:I, s:I}",
         "requests_received",    (json_int_t)priv->st_requests_received,
         "responses_sent",       (json_int_t)priv->st_responses_sent,
         "token_requests",       (json_int_t)priv->st_token_requests,
         "logout_requests",      (json_int_t)priv->st_logout_requests,
+        "discovery_requests",   (json_int_t)priv->st_discovery_requests,
         "unknown_requests",     (json_int_t)priv->st_unknown_requests,
         "deferred_responses",   (json_int_t)priv->st_deferred_responses,
         "pending_cancelled",    (json_int_t)priv->st_pending_cancelled
@@ -542,9 +545,38 @@ PRIVATE int ac_on_message(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
      *  Route by url suffix.  The BFF posts to
      *    /realms/<realm>/protocol/openid-connect/token
      *    /realms/<realm>/protocol/openid-connect/logout
+     *  and GETs
+     *    /realms/<realm>/.well-known/openid-configuration
      *  so a plain strstr is enough for the test.
      */
-    if(strstr(url, "/token")) {
+    if(strstr(url, "/.well-known/openid-configuration")) {
+        priv->st_discovery_requests++;
+        /*
+         *  OIDC discovery: derive issuer + endpoints from the request's
+         *  Host header so the BFF can reach us back on the same socket.
+         */
+        json_t *jn_headers = kw_get_dict(gobj, kw, "headers", NULL, 0);
+        const char *host_hdr = jn_headers ?
+            kw_get_str(gobj, jn_headers, "HOST", "127.0.0.1", 0) : "127.0.0.1";
+
+        char issuer_url[512];
+        char token_url[512];
+        char logout_url[512];
+        snprintf(issuer_url, sizeof(issuer_url),
+            "http://%s/realms/test", host_hdr);
+        snprintf(token_url, sizeof(token_url),
+            "http://%s/realms/test/protocol/openid-connect/token", host_hdr);
+        snprintf(logout_url, sizeof(logout_url),
+            "http://%s/realms/test/protocol/openid-connect/logout", host_hdr);
+
+        json_t *jn_body = json_pack("{s:s, s:s, s:s}",
+            "issuer",               issuer_url,
+            "token_endpoint",       token_url,
+            "end_session_endpoint", logout_url
+        );
+        respond_or_defer(gobj, src, 200, "200 OK", jn_body);
+
+    } else if(strstr(url, "/token")) {
         priv->st_token_requests++;
 
         int status            = (int)gobj_read_integer_attr(gobj, "return_status");

--- a/tests/c/c_auth_bff/c_mock_keycloak.c
+++ b/tests/c/c_auth_bff/c_mock_keycloak.c
@@ -554,6 +554,14 @@ PRIVATE int ac_on_message(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
         /*
          *  OIDC discovery: derive issuer + endpoints from the request's
          *  Host header so the BFF can reach us back on the same socket.
+         *
+         *  Always answered synchronously, regardless of latency_ms.
+         *  latency_ms emulates a slow /token endpoint (the test's
+         *  subject-under-test); discovery is BFF startup wiring and
+         *  must not contend for the single pending-response slot, or
+         *  the real flow would race against it (test7: bumps
+         *  responses_sent/deferred_responses; test8: holds the BFF in
+         *  !discovery_done while POSTs pile up in dl_pending).
          */
         json_t *jn_headers = kw_get_dict(gobj, kw, "headers", NULL, 0);
         const char *host_hdr = jn_headers ?
@@ -574,7 +582,23 @@ PRIVATE int ac_on_message(hgobj gobj, gobj_event_t event, json_t *kw, hgobj src)
             "token_endpoint",       token_url,
             "end_session_endpoint", logout_url
         );
-        respond_or_defer(gobj, src, 200, "200 OK", jn_body);
+        /*
+         *  Send inline (not via mk_send_json) so the discovery exchange
+         *  does NOT increment st_responses_sent — every test's mock-KC
+         *  assertions count token+logout responses only; discovery has
+         *  its own st_discovery_requests counter.
+         */
+        json_t *kw_resp = json_pack("{s:s, s:s, s:o}",
+            "code",     "200 OK",
+            "headers",  "",
+            "body",     jn_body
+        );
+        gobj_send_event(src, EV_SEND_MESSAGE, kw_resp, gobj);
+        if(gobj_trace_level(gobj) & TRACE_MESSAGES) {
+            gobj_trace_msg(gobj,
+                "mock-kc → %s: discovery 200", gobj_short_name(src)
+            );
+        }
 
     } else if(strstr(url, "/token")) {
         priv->st_token_requests++;

--- a/tests/c/c_auth_bff/main_test10_kc_silence.c
+++ b/tests/c/c_auth_bff/main_test10_kc_silence.c
@@ -122,8 +122,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test11_cancel_retry.c
+++ b/tests/c/c_auth_bff/main_test11_cancel_retry.c
@@ -112,8 +112,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test11_cancel_retry.c
+++ b/tests/c/c_auth_bff/main_test11_cancel_retry.c
@@ -112,7 +112,8 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
+                                'token_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/token', \n\
+                                'end_session_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/logout', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test12_stale_reply.c
+++ b/tests/c/c_auth_bff/main_test12_stale_reply.c
@@ -115,7 +115,8 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
+                                'token_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/token', \n\
+                                'end_session_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/logout', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test12_stale_reply.c
+++ b/tests/c/c_auth_bff/main_test12_stale_reply.c
@@ -115,8 +115,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test13_refresh_expired.c
+++ b/tests/c/c_auth_bff/main_test13_refresh_expired.c
@@ -118,8 +118,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test14_method_not_allowed.c
+++ b/tests/c/c_auth_bff/main_test14_method_not_allowed.c
@@ -113,8 +113,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test15_missing_body.c
+++ b/tests/c/c_auth_bff/main_test15_missing_body.c
@@ -113,8 +113,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test16_unknown_endpoint.c
+++ b/tests/c/c_auth_bff/main_test16_unknown_endpoint.c
@@ -113,8 +113,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test1_login.c
+++ b/tests/c/c_auth_bff/main_test1_login.c
@@ -124,8 +124,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test2_kc_401.c
+++ b/tests/c/c_auth_bff/main_test2_kc_401.c
@@ -117,8 +117,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test3_callback.c
+++ b/tests/c/c_auth_bff/main_test3_callback.c
@@ -114,8 +114,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test4_refresh.c
+++ b/tests/c/c_auth_bff/main_test4_refresh.c
@@ -114,8 +114,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test5_logout.c
+++ b/tests/c/c_auth_bff/main_test5_logout.c
@@ -112,8 +112,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test6_invalid_body.c
+++ b/tests/c/c_auth_bff/main_test6_invalid_body.c
@@ -113,8 +113,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test7_slow_login.c
+++ b/tests/c/c_auth_bff/main_test7_slow_login.c
@@ -114,8 +114,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test8_queue_full.c
+++ b/tests/c/c_auth_bff/main_test8_queue_full.c
@@ -118,8 +118,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test8_queue_full.c
+++ b/tests/c/c_auth_bff/main_test8_queue_full.c
@@ -118,7 +118,8 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
+                                'token_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/token', \n\
+                                'end_session_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/logout', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test9_browser_cancel.c
+++ b/tests/c/c_auth_bff/main_test9_browser_cancel.c
@@ -119,8 +119,7 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'idp_url': 'http://127.0.0.1:"KC_PORT"/', \n\
-                                'realm':        'test',             \n\
+                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/tests/c/c_auth_bff/main_test9_browser_cancel.c
+++ b/tests/c/c_auth_bff/main_test9_browser_cancel.c
@@ -119,7 +119,8 @@ PRIVATE char variable_config[]= "\
                             'name': 'bff-1',                        \n\
                             'gclass': 'C_AUTH_BFF',                 \n\
                             'kw': {                                 \n\
-                                'issuer': 'http://127.0.0.1:"KC_PORT"/realms/test/', \n\
+                                'token_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/token', \n\
+                                'end_session_endpoint': 'http://127.0.0.1:"KC_PORT"/realms/test/protocol/openid-connect/logout', \n\
                                 'client_id':    'test-client',      \n\
                                 'client_secret': '',                \n\
                                 'cookie_domain': '',                \n\

--- a/yunos/c/auth_bff/batches/localhost/auth_bff.1801.json
+++ b/yunos/c/auth_bff/batches/localhost/auth_bff.1801.json
@@ -52,8 +52,7 @@
                             "name": "bff-(^^__range__^^)",
                             "gclass": "C_AUTH_BFF",
                             "kw": {
-                                "idp_url": "https://auth.artgins.com/",
-                                "realm": "yunetas.com",
+                                "issuer": "https://auth.artgins.com/realms/yunetas.com/",
                                 "client_id": "treedb.yunetas.com",
                                 "client_secret": "",
                                 "cookie_domain": "",


### PR DESCRIPTION
## Summary

Migrates `c_auth_bff` (Backend-for-Frontend) and `c_task_authenticate` (ROPC task) from a Keycloak-only path scheme to standard OIDC discovery with explicit endpoint override support. Both gclasses now support three configuration modes in priority order:

1. **Explicit endpoints** — set `token_endpoint` + `end_session_endpoint` directly (skips discovery)
2. **OIDC discovery** — set `issuer` URL; BFF/task GETs `/.well-known/openid-configuration` at startup
3. **Legacy Keycloak path scheme** — `idp_url` + `realm` (deprecated, emits warning)

## Key Changes

### `c_auth_bff` (Backend-for-Frontend)

- **New attributes**: `issuer`, `token_endpoint`, `end_session_endpoint`
- **Deprecated attributes**: `idp_url`, `realm` (marked with deprecation warnings in descriptions)
- **Discovery flow**: At `mt_start`, if `issuer` is configured, spawns a one-shot discovery task that GETs `<issuer>/.well-known/openid-configuration` and caches resolved endpoints
- **Request queueing**: Browser requests arriving before discovery completes queue in `dl_pending`; `process_next()` gates on `priv->discovery_done` to hold them until endpoints are resolved
- **Endpoint parsing**: Token and logout calls now parse full endpoint URLs (not just path components) via `parse_url()` to extract the resource path
- **Status reporting**: `cmd_view_status` now includes `discovery_done`, `issuer`, `token_endpoint`, `end_session_endpoint` fields
- **Mock Keycloak**: Updated test mock to handle `/.well-known/openid-configuration` GET requests and derive issuer/endpoints from Host header

### `c_task_authenticate` (ROPC Task)

- **New attributes**: `issuer`, `token_endpoint`, `end_session_endpoint`
- **Deprecated attributes**: `auth_url`, `auth_system` (latter is now a no-op; kept for back-compat)
- **Discovery integration**: When `issuer` is set, prepends `[action_discover, result_save_discovery]` to the task job chain before the token/logout actions
- **Failure handling**: Discovery failures publish `EV_ON_TOKEN` with result=-1 so callers don't hang
- **Endpoint parsing**: Token and logout actions now parse full endpoint URLs to extract resource paths

### Test & Config Updates

- All 16 BFF tests migrated to use `issuer` attribute (tests 1–7, 10) or explicit endpoints (tests 8–9, 11–12)
- Production batch `auth_bff.1801.json` migrated to `issuer`
- Performance and stress test configs updated to use `issuer`

### Documentation

- Added `TODO.md` tracking deprecation timeline, test coverage gaps, and six callers still using legacy `auth_url` that need migration:
  - `yuno_cli`, `mqtt_tui`, `ycommand`, `ystats`, `ytests`, `ybatch`
- Updated header comments in both gclasses to document the three configuration modes and discovery flow

## Implementation Details

- **Discovery gating**: `process_next()` in BFF and the task job chain both check `discovery_done` before proceeding; prevents race conditions where requests execute before endpoints are resolved
- **URL parsing**: Refactored from storing parsed URL components (`schema`, `host`, `port`, `path`) to storing full endpoint URLs and parsing them on-demand per request
- **Legacy path construction**: Keycloak scheme now builds full URLs (`<base>/protocol/openid-connect/token` and `.../logout`) at startup rather than composing paths per-request
- **Connection reuse**: Both discovery and auth flows use the same HTTP client connection (same host/port), reducing connection overhead
- **Backward compatibility**: Legacy `idp_url`+`realm` and `auth_url` paths still work; deprecation warnings guide operators to migrate

https://claude.ai/code/session_01WSYx9C8vHGVbQvdn4TYD1R