### PR TITLE
Add deprecation warnings for deprecated attributes in gobj creation

### DIFF
--- a/kernel/c/gobj-c/src/gobj.c
+++ b/kernel/c/gobj-c/src/gobj.c
@@ -2730,6 +2730,16 @@ PRIVATE int json2sdata(
         if(!(flag == -1 || (it->flag & flag))) {
             continue;
         }
+        if(it->flag & SDF_DEPRECATED) {
+            gobj_log_warning(gobj, 0,
+                "function",     "%s", __FUNCTION__,
+                "msgset",       "%s", MSGSET_PARAMETER,
+                "msg",          "%s", "Deprecated attribute used in gobj creation",
+                "gclass",       "%s", gobj_gclass_name(gobj),
+                "attr",         "%s", key,
+                NULL
+            );
+        }
         ret += json2item(gobj, hsdata, it, jn_value);
     }
 

--- a/kernel/js/gobj-js/src/gobj.js
+++ b/kernel/js/gobj-js/src/gobj.js
@@ -1338,6 +1338,9 @@ function json2sdata(
         if(!(flag === -1 || (it.flag & flag))) {
             continue;
         }
+        if(it.flag & sdata_flag_t.SDF_DEPRECATED) {
+            log_warning(`${gobj_short_name(gobj)}: Deprecated attribute used in gobj creation: ${key}`);
+        }
         ret += json2item(gobj, hsdata, it, jn_value);
     }
 


### PR DESCRIPTION
## Summary
Added deprecation warnings that are logged when deprecated attributes (marked with `SDF_DEPRECATED` flag) are used during gobj creation. This helps developers identify and migrate away from deprecated attributes.

## Key Changes
- **C implementation** (`gobj.c`): Added a check in the `json2sdata()` function to detect when an attribute has the `SDF_DEPRECATED` flag set and log a warning with relevant context (gclass name, attribute name, etc.)
- **JavaScript implementation** (`gobj.js`): Added equivalent deprecation warning logic in the `json2sdata()` function to maintain feature parity across both implementations

## Implementation Details
- The deprecation check is performed after the flag validation but before processing the attribute value
- Warnings include contextual information such as:
  - In C: function name, message set, gclass name, and the deprecated attribute name
  - In JavaScript: gobj short name and the deprecated attribute name
- The deprecated attributes are still processed normally; the warning is purely informational to guide developers toward non-deprecated alternatives

https://claude.ai/code/session_01ED3WHgQP4tTiY9xRkarm1H