### PR TITLE
Add i18n locale validation and fix dropdown anchor drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
       `refresh_language()` walks `[data-i18n-aria-label]` to rewrite
       `aria-label`.  Screen-reader names now follow the active locale.
 
+    - **fix(lib-yui): toolbar dropdown anchor drift on scroll/resize**.
+      The `position:fixed` panel coordinates are frozen at open time
+      from `getBoundingClientRect()`; any layout shift previously left
+      the panel detached from its trigger.  Match native `<select>` UX
+      and dismiss the dropdown on scroll (capture, passive — catches
+      every ancestor scroller) and on window resize.
+
 ## v7.3.1 -- 30/Apr/2026
     - **breaking(auth): standard OIDC migration of `c_auth_bff` and
       `c_task_authenticate`**.  Both gclasses now resolve IdP endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@
       and dismiss the dropdown on scroll (capture, passive — catches
       every ancestor scroller) and on window resize.
 
+    - **feat(yuno-skeleton): locale convention + validator**.  The
+      `js_gui` template now ships `scripts/validate-locales.mjs`
+      (asserts every i18n key is ASCII + lower-case + present in every
+      locale) wired as `npm run validate-locales` and `prebuild`.
+      en.js/es.js header banners spell out the convention so new
+      yunos inherit it from day one.
+
 ## v7.3.1 -- 30/Apr/2026
     - **breaking(auth): standard OIDC migration of `c_auth_bff` and
       `c_task_authenticate`**.  Both gclasses now resolve IdP endpoints

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -1354,6 +1354,15 @@ function open_toolbar_dropdown(gobj, item, action, $trigger)
         return;
     }
 
+    /*  The panel mounts on priv.layers.popup, which is a sibling of the
+     *  shell's $container.  refresh_language($container, t) therefore
+     *  does NOT walk into an open dropdown.  This is currently safe
+     *  because every sub-item handler (build_dropdown_row) closes the
+     *  dropdown before publishing its event, so by the time a language
+     *  switch fires the panel is already gone.  If a future caller
+     *  triggers a language switch while leaving the dropdown open,
+     *  rerun refresh_language on $panel — or move the panel under
+     *  $container (the popup layer is full-screen). */
     let aria_key = item && (item.aria_label || item.name || item.id) || "Menu";
     let i18n_aria = (item && (item.aria_label || item.name)) || "Menu";
     let $panel = createElement2(["div", {
@@ -1408,9 +1417,19 @@ function open_toolbar_dropdown(gobj, item, action, $trigger)
     };
     document.addEventListener("mousedown", backdrop, true);
 
+    /*  Scroll/resize: the panel anchor was frozen at open time from
+     *  getBoundingClientRect(); any layout shift drifts it from the
+     *  trigger.  Match native <select> UX and dismiss on either.
+     *  Capture-phase + passive scroll so we hear all scrollers (any
+     *  ancestor, not just window) without blocking them. */
+    let dismiss = () => close_toolbar_dropdown(gobj);
+    document.addEventListener("scroll", dismiss, {capture: true, passive: true});
+    window.addEventListener("resize", dismiss);
+
     let close_fn = () => close_toolbar_dropdown(gobj);
     $panel.__yui_close_handler__   = close_fn;
     $panel.__yui_backdrop_handler__ = backdrop;
+    $panel.__yui_dismiss_handler__  = dismiss;
     $panel.__yui_trigger__          = $trigger || null;
     push_escape(gobj, "popup", close_fn);
 
@@ -1445,6 +1464,13 @@ function close_toolbar_dropdown(gobj)
         document.removeEventListener("mousedown",
                                      $panel.__yui_backdrop_handler__, true);
         $panel.__yui_backdrop_handler__ = null;
+    }
+    if($panel.__yui_dismiss_handler__) {
+        document.removeEventListener("scroll",
+                                     $panel.__yui_dismiss_handler__,
+                                     {capture: true});
+        window.removeEventListener("resize", $panel.__yui_dismiss_handler__);
+        $panel.__yui_dismiss_handler__ = null;
     }
     if($panel.__yui_trigger__) {
         $panel.__yui_trigger__.setAttribute("aria-expanded", "false");

--- a/utils/c/yuno-skeleton/skeletons/js_gui/package.json_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/js_gui/package.json_tmpl
@@ -7,7 +7,9 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "validate-locales": "node scripts/validate-locales.mjs",
+        "prebuild": "npm run validate-locales"
     },
     "dependencies": {
         "bulma": "^1.0.4",

--- a/utils/c/yuno-skeleton/skeletons/js_gui/scripts/validate-locales.mjs_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/js_gui/scripts/validate-locales.mjs_tmpl
@@ -1,0 +1,82 @@
+/***********************************************************************
+ *          validate-locales.mjs
+ *
+ *          Enforce the i18n key conventions on every bundled locale:
+ *
+ *            1. Keys are ASCII (no em-dash, accents, etc.).
+ *            2. Keys are lower-case.
+ *            3. All locales carry the same key set (symmetric).
+ *
+ *          Run via `npm run validate-locales` or as a vite prebuild
+ *          step.  Exits 1 on any violation so CI fails loudly.
+ *
+ *          Imports the per-locale modules directly (en.js, es.js)
+ *          rather than going through locales.js — the wrapper drags in
+ *          @yuneta/gobj-js + i18next which expect a browser global.
+ *          Add new locales to the LOCALES list below as they land.
+ *
+ *          Copyright (c) {{__year__}}, {{author}}.
+ *          All Rights Reserved.
+ ***********************************************************************/
+import {en} from "../src/locales/en.js";
+import {es} from "../src/locales/es.js";
+
+const LOCALES = {en, es};
+
+const ASCII_RE = /^[\x20-\x7e]+$/;
+
+function fail(msg) {
+    process.stderr.write(`validate-locales: ${msg}\n`);
+}
+
+function main() {
+    const codes = Object.keys(LOCALES);
+    let errors = 0;
+
+    /*  Per-locale key checks (ASCII + lower-case). */
+    const key_sets = {};
+    for(const code of codes) {
+        const t = (LOCALES[code] && LOCALES[code].translation) || {};
+        const keys = Object.keys(t);
+        key_sets[code] = new Set(keys);
+        for(const k of keys) {
+            if(!ASCII_RE.test(k)) {
+                fail(`[${code}] non-ASCII key: ${JSON.stringify(k)}`);
+                errors++;
+            }
+            if(k !== k.toLowerCase()) {
+                fail(`[${code}] non-lower-case key: ${JSON.stringify(k)}`);
+                errors++;
+            }
+        }
+    }
+
+    /*  Symmetry: every locale must carry the same keys as the first. */
+    const ref = codes[0];
+    const ref_keys = key_sets[ref];
+    for(const code of codes.slice(1)) {
+        const cur = key_sets[code];
+        for(const k of ref_keys) {
+            if(!cur.has(k)) {
+                fail(`[${code}] missing key present in [${ref}]: ${JSON.stringify(k)}`);
+                errors++;
+            }
+        }
+        for(const k of cur) {
+            if(!ref_keys.has(k)) {
+                fail(`[${code}] extra key not in [${ref}]: ${JSON.stringify(k)}`);
+                errors++;
+            }
+        }
+    }
+
+    if(errors > 0) {
+        fail(`${errors} violation(s) — see above`);
+        process.exit(1);
+    }
+
+    process.stdout.write(
+        `validate-locales: OK (${codes.length} locales × ${ref_keys.size} keys)\n`);
+}
+
+main();

--- a/utils/c/yuno-skeleton/skeletons/js_gui/src/locales/en.js_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/js_gui/src/locales/en.js_tmpl
@@ -1,9 +1,15 @@
 /***********************************************************************
  *          en.js
  *
- *          English translations.  Keys follow the lower-case English
- *          phrasing that lib-yui's `data-i18n` attributes carry by
- *          default; a missing key falls through to the key itself.
+ *          English translations.
+ *
+ *          Convention (all locale files share these rules):
+ *            1. Keys are lower-case ASCII English.
+ *            2. Values are sentence-case in their target language —
+ *               a missing translation falls through to the lower-case
+ *               key, making the gap visible to the user at a glance.
+ *            3. Every locale file must carry the *same* key set; see
+ *               scripts/validate-locales.mjs.
  *
  *          Copyright (c) {{__year__}}, {{author}}.
  *          All Rights Reserved.

--- a/utils/c/yuno-skeleton/skeletons/js_gui/src/locales/es.js_tmpl
+++ b/utils/c/yuno-skeleton/skeletons/js_gui/src/locales/es.js_tmpl
@@ -1,9 +1,15 @@
 /***********************************************************************
  *          es.js
  *
- *          Traducciones al español.  Las claves siguen el texto inglés
- *          que lib-yui pone por defecto en los `data-i18n`; si no
- *          existe la clave aquí, se muestra la propia clave.
+ *          Traducciones al español.
+ *
+ *          Convention (all locale files share these rules):
+ *            1. Keys are lower-case ASCII English.
+ *            2. Values are sentence-case in their target language —
+ *               a missing translation falls through to the lower-case
+ *               key, making the gap visible to the user at a glance.
+ *            3. Every locale file must carry the *same* key set; see
+ *               scripts/validate-locales.mjs.
  *
  *          Copyright (c) {{__year__}}, {{author}}.
  *          All Rights Reserved.


### PR DESCRIPTION
## Summary
This PR adds i18n locale validation tooling to enforce consistent key conventions across all locale files, and fixes a UI bug where toolbar dropdowns drift from their trigger on scroll/resize events.

## Key Changes

- **New locale validator** (`scripts/validate-locales.mjs`):
  - Enforces three i18n key conventions: ASCII-only, lower-case, and symmetric key sets across all locales
  - Wired as `npm run validate-locales` and runs as a `prebuild` step to catch violations early in CI
  - Imports locale modules directly to avoid browser globals during validation
  - Provides clear error messages for each violation type

- **Updated locale file headers** (en.js, es.js):
  - Documented the three-rule convention in both English and Spanish templates
  - Clarifies that keys are lower-case ASCII, values are sentence-case in target language, and all locales must share the same key set

- **Fixed toolbar dropdown anchor drift**:
  - Added scroll and resize event listeners (capture phase, passive scroll) to dismiss dropdowns when layout shifts occur
  - Matches native `<select>` UX behavior
  - Properly cleans up event listeners on dropdown close to prevent memory leaks
  - Added detailed comments explaining why the panel is a sibling of `$container` and the implications for language switching

- **Updated package.json**:
  - Added `validate-locales` and `prebuild` npm scripts to the js_gui template

## Implementation Details

The validator uses a reference locale (first in the LOCALES list) to check symmetry, ensuring all other locales carry identical key sets. The scroll listener uses capture phase to catch all ancestor scrollers, not just window-level scrolling. Event cleanup is explicit to avoid dangling references when dropdowns close.

https://claude.ai/code/session_01LMUA6RhSuJHnrqRfbrvgsQ