### PR TITLE
Add decorative header/divider items for visual grouping in submenus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # **Changelog**
 
 ## Unreleased
+    - **fix(lib-yui): bare-route redirect skips decorative items**.
+      `navigate_to()` was using `submenu.items[0].route` as the
+      fallback for a level-1 container — undefined when item 0 is a
+      `type:"header"` / `type:"divider"`, which caused the bare route
+      to fall through to "no target".  Use the first item with a
+      `route` instead; `submenu.default` still wins.  SHELL.md §3
+      updated.
+
     - **feat(lib-yui): item tooltips**.  Nav and toolbar items accept a
       `tooltip` field (fallback: `aria_label`); rendered as the HTML
       `title` attribute on the generated `<a>`/`<button>`.

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -343,7 +343,9 @@ menu label.
   - `stage` — where to mount it (defaults to `main`).
   - `lifecycle`: `eager` | `keep_alive` | `lazy_destroy`.
 - `submenu` — when declared, the item becomes a *container*: its bare
-  route redirects to the first sub-item (or to `submenu.default`).
+  route redirects to the first navigable sub-item (or to `submenu.default`
+  if set).  Decorative entries (§3.5) carry no `route` and are skipped
+  by this fallback, so a header may safely sit at position 0.
   Sub-items declare their own `target`.
 
 #### Decorative items inside a submenu — `type:"header"` / `type:"divider"`

--- a/kernel/js/lib-yui/SHELL.md
+++ b/kernel/js/lib-yui/SHELL.md
@@ -54,7 +54,9 @@ keyed on `data-toolbar-item-id`, the shell got better at its job.
    `left` on desktop and in `bottom` on mobile"* without duplicating the
    menu definition or breaking the panels' internal state.
 3. **Two-level navigation**: primary options + sub-options, mapped to
-   hash routes (`#/primary/secondary`).
+   hash routes (`#/primary/secondary`).  Apps that need a third level
+   of grouping inside the secondary use `type:"header"` / `type:"divider"`
+   decorative items (§3.5) — visual chunking without a third nav level.
 4. **Pluggable per-zone rendering**: the same menu option must be able
    to render differently depending on where it lands (vertical icon +
    label in `left`; icon-over-label in `bottom`; horizontal tabs in
@@ -344,6 +346,65 @@ menu label.
   route redirects to the first sub-item (or to `submenu.default`).
   Sub-items declare their own `target`.
 
+#### Decorative items inside a submenu — `type:"header"` / `type:"divider"`
+
+When a secondary nav has many leaves, group them visually with two
+non-interactive item kinds. The shell's route indexer ignores them
+(no `route`, no `target`); the renderers in `vertical`, `submenu`,
+`drawer` and `accordion` paint them; `tabs` and `icon-bar` silently
+drop them — there is no room for section labels in those compact
+layouts.
+
+```json
+"submenu": {
+  "render": { "top-sub": "tabs", "right": "vertical" },
+  "items": [
+    { "type": "header",  "name": "account" },
+    { "id": "profile",  "name": "my profile",
+      "route": "/system/account/profile",
+      "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                  "kw": { "title": "my profile" } } },
+    { "id": "sessions", "name": "sessions",
+      "route": "/system/account/sessions",
+      "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                  "kw": { "title": "sessions" } } },
+    { "type": "divider" },
+    { "type": "header",  "name": "infrastructure" },
+    { "id": "tariffs",  "name": "tariffs",
+      "route": "/system/infra/tariffs",
+      "target": { "stage": "main", "gclass": "C_TEST_VIEW",
+                  "kw": { "title": "tariffs" } } }
+  ]
+}
+```
+
+Field rules:
+
+- `type: "header"` — required `name` (translatable, emitted with
+  `data-i18n`). Renders as a small-caps section label, no anchor.
+- `type: "divider"` — no other fields. Renders as a 1 px horizontal
+  rule, `role="separator"`, `aria-hidden="true"`.
+
+Both kinds carry no `route`/`target`/`submenu`, so they are skipped
+by `enter_route`, by the route index, and by the click handler
+(`closest("[data-route]")` returns nothing).
+
+This lets an app keep a flat 2-level navigation tree (one of the
+shell's deliberate constraints, see §1 goal #3) while still
+expressing more than two levels of *meaning* — the third level is
+purely visual chunking inside the secondary nav.
+
+### 3.6 `menu.<id>.render[zone].layout` — when each layout is appropriate
+
+| Layout       | Best zone(s)         | Renders header/divider? | Notes                                  |
+|--------------|----------------------|-------------------------|----------------------------------------|
+| `vertical`   | `left`, `right`      | yes                     | Bulma `.menu`. Default secondary.       |
+| `submenu`    | `right`, `top-sub`   | yes                     | Vertical list with a heading on top.    |
+| `drawer`     | `overlay` (off-canvas)| yes (delegates to vertical) | Toggled by toolbar burger.        |
+| `accordion`  | `left`               | yes (in inner items)    | Collapsible groups; first-level entries are sections, not decorations. |
+| `tabs`       | `top-sub`            | no — silently dropped   | Horizontal strip; no room for labels.   |
+| `icon-bar`   | `bottom`             | no — silently dropped   | Mobile primary; one slot per icon.      |
+
 ---
 
 ## 4. Lifecycle
@@ -565,6 +626,7 @@ managing its visibility.
 | Declarative, Yuneta-style JSON                           | `config` attribute holding a JSON of `shell`/`menu`/`toolbar` |
 | Layers + working zones                                   | 6 fixed layers + 7 zones in a grid                            |
 | Two-level primary menu                                   | `menu.primary.items[].submenu.items[]`                        |
+| Three-level *meaning* without a third nav level          | `type:"header"` / `type:"divider"` decorative items inside `submenu.items[]` (§3.5) |
 | Primary in `left` on desktop and `bottom` on mobile      | `"host": "menu.primary"` in both, with opposite `show_on`     |
 | Icon + label; different per zone                         | `render[zone]` with `layout` + `icon_pos` + `show_label`      |
 | Submenu as tabs **or** as a side submenu                 | `submenu.render[zone]` set to `"tabs"` / `"vertical"` / etc.  |
@@ -630,6 +692,9 @@ shell. Treat the two APIs as parallel — same intent, separate code.
 - All 6 menu layouts (`vertical`, `icon-bar`, `tabs`, `drawer`,
   `submenu`, `accordion`), with auto-expansion of the active branch
   on accordion when the route changes.
+- Decorative `type:"header"` / `type:"divider"` items inside
+  secondary navs (§3.5) — visual chunking of long submenus without
+  introducing a third routing level.
 - Off-canvas drawer: mounted on the `overlay` layer (not inside the
   zone grid), closed on backdrop click and on `Escape`, public API
   `yui_shell_{open,close,toggle}_drawer`, focus-trap with

--- a/kernel/js/lib-yui/src/c_yui_nav.js
+++ b/kernel/js/lib-yui/src/c_yui_nav.js
@@ -16,6 +16,17 @@
  *      Each item supports:
  *          id, name, icon (CSS class or svg id), route, badge, disabled
  *
+ *      In addition to navigable items, secondary navs accept two
+ *      decorative item kinds for in-place visual grouping:
+ *
+ *          { "type": "header",  "name": "<group label>" }
+ *          { "type": "divider" }
+ *
+ *      Headers render as a small-caps section label; dividers as a thin
+ *      separator line.  Both are non-clickable and skipped by routing
+ *      and click handling.  Layouts that have no room for them
+ *      (`tabs`, `icon-bar`) silently drop these entries.
+ *
  *          Copyright (c) 2026, ArtGins.
  *          All Rights Reserved.
  ***********************************************************************/
@@ -39,6 +50,14 @@ const GCLASS_NAME = "C_YUI_NAV";
 const SUPPORTED_LAYOUTS = [
     "vertical", "icon-bar", "tabs", "drawer", "submenu", "accordion"
 ];
+
+/*  Decorative items have no `route` and never participate in
+ *  navigation; the shell's route indexer already skips items
+ *  without a route, so this only affects the rendering side. */
+function is_decorative(it)
+{
+    return !!(it && (it.type === "header" || it.type === "divider"));
+}
 
 /***************************************************************
  *              Attrs
@@ -237,6 +256,9 @@ function render_icon_bar(gobj, items)
 
     let bar_items = [];
     for(let it of items) {
+        if(is_decorative(it)) {
+            continue;   /*  headers/dividers don't fit a horizontal icon bar  */
+        }
         bar_items.push(item_iconbar(gobj, it, { icon_pos, show_label }));
     }
     return createElement2(
@@ -250,6 +272,9 @@ function render_tabs(gobj, items)
 
     let lis = [];
     for(let it of items) {
+        if(is_decorative(it)) {
+            continue;   /*  tab strips have no room for section labels  */
+        }
         let children = [];
         if(!empty_string(it.icon)) {
             children.push(["span", {class: "icon is-small"},
@@ -346,6 +371,9 @@ function render_accordion(gobj, items)
 
     let $root = createElement2(["aside", {class: "menu yui-nav-accordion p-2"}]);
     for(let it of items) {
+        if(is_decorative(it)) {
+            continue;   /*  primary-level decorations don't apply to accordion sections  */
+        }
         let acc_id = ++__nav_aria_seq__;
         let head_id = `yui-acc-head-${acc_id}`;
         let body_id = `yui-acc-body-${acc_id}`;
@@ -389,6 +417,29 @@ function render_accordion(gobj, items)
  ************************************************************/
 function item_li(gobj, it, opts)
 {
+    /*  Decorative entries: a non-interactive section header or a
+     *  thin divider rule.  Used inside vertical/submenu/accordion
+     *  navs to chunk the list visually without introducing a third
+     *  navigation level.  Both render as <li> with no <a>, so the
+     *  click handler's `closest("[data-route]")` skips them. */
+    if(it && it.type === "divider") {
+        return ["li", {
+            class: "yui-nav-section-divider",
+            role: "separator",
+            "aria-hidden": "true"
+        }];
+    }
+    if(it && it.type === "header") {
+        let label = it.name || "";
+        let span_attrs = {class: "yui-nav-section-header-label"};
+        if(label) {
+            span_attrs.i18n = label;
+        }
+        return ["li", {class: "yui-nav-section-header", role: "presentation"},
+            ["span", span_attrs, label]
+        ];
+    }
+
     let { icon_pos, show_label, stacked } = opts;
     let children = [];
     let label = it.name || "";

--- a/kernel/js/lib-yui/src/c_yui_shell.css
+++ b/kernel/js/lib-yui/src/c_yui_shell.css
@@ -208,6 +208,30 @@
     transform: none;
 }
 
+/*--- section header / divider (decorative items inside vertical/submenu) ---*/
+.yui-nav .menu-list .yui-nav-section-header {
+    list-style: none;
+    margin: 0.75rem 0 0.125rem;
+    padding: 0.125rem 0.5rem;
+}
+.yui-nav .menu-list .yui-nav-section-header:first-child {
+    margin-top: 0.125rem;
+}
+.yui-nav .menu-list .yui-nav-section-header-label {
+    display: inline-block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    color: var(--bulma-text-weak, #6b7280);
+}
+.yui-nav .menu-list .yui-nav-section-divider {
+    list-style: none;
+    height: 1px;
+    margin: 0.5rem 0.5rem;
+    background-color: var(--bulma-border-weak, #dbdbdb);
+}
+
 /*============================================================
  *      Active item highlight (Bulma already styles .is-active
  *      on .menu-list a and on .tabs li; we just ensure a

--- a/kernel/js/lib-yui/src/c_yui_shell.js
+++ b/kernel/js/lib-yui/src/c_yui_shell.js
@@ -861,10 +861,13 @@ function navigate_to(gobj, route)
     }
     let entry = priv.item_index[route];
 
-    /*  Route level 1 only: if it has a submenu, navigate to its default subitem */
+    /*  Route level 1 only: if it has a submenu, navigate to its default subitem.
+     *  Skip decorative items (`type:"header"`, `type:"divider"`) — they have
+     *  no `route`, so the first *navigable* child is used as the fallback.   */
     if(entry && !entry.target && entry.item && entry.item.submenu) {
         let sub = entry.item.submenu;
-        let default_sub = sub.default || (sub.items && sub.items[0] && sub.items[0].route);
+        let first_routable = sub.items && sub.items.find(it => it && it.route);
+        let default_sub = sub.default || (first_routable && first_routable.route);
         if(default_sub) {
             return navigate_to(gobj, default_sub);
         }


### PR DESCRIPTION
## Summary
This PR introduces support for decorative `type:"header"` and `type:"divider"` items in secondary navigation menus, enabling visual grouping of submenu items without introducing a third navigation level. It also fixes a bug where bare-route redirects would fail if the first submenu item was decorative.

## Key Changes

- **New decorative item types**: Added `type:"header"` (renders as small-caps section label) and `type:"divider"` (renders as thin separator line) for use inside `submenu.items[]`
  - Headers require a `name` field (translatable via `data-i18n`)
  - Dividers have no additional fields
  - Both are non-interactive and skipped by routing logic

- **Route handling fix**: Modified `navigate_to()` to skip decorative items when finding the fallback route for a submenu container
  - Previously used `submenu.items[0].route` which would be undefined for decorative items
  - Now finds the first item with an actual `route` property
  - `submenu.default` still takes precedence

- **Layout-aware rendering**: Updated renderers to handle decorative items appropriately
  - `vertical`, `submenu`, `drawer`, `accordion`: render headers and dividers
  - `tabs`, `icon-bar`: silently skip decorative items (no room in compact layouts)
  - Added `is_decorative()` helper function to identify these items

- **Styling**: Added CSS rules for decorative items
  - Headers: small-caps uppercase text with weak color
  - Dividers: 1px horizontal rule with appropriate margins

- **Documentation**: Updated SHELL.md with detailed examples and a layout compatibility table (§3.5, §3.6)

## Implementation Details

- Decorative items carry no `route`, `target`, or `submenu` properties, so they're naturally skipped by the route indexer
- The click handler's `closest("[data-route]")` naturally ignores them since they render as `<li>` without an `<a>` child
- This maintains the shell's deliberate 2-level navigation constraint while allowing 3-level *visual* grouping

https://claude.ai/code/session_01HJvYeQDb1aW4wYxGcnKqKx