### PR TITLE
lib-yui: fix G6 v5 canvas panning (touch broken, desktop desynced)

### DIFF
--- a/kernel/js/lib-yui/src/c_g6_nodes_tree.js
+++ b/kernel/js/lib-yui/src/c_g6_nodes_tree.js
@@ -95,6 +95,7 @@ import {Circle as CircleGeometry} from '@antv/g';
 import i18next, {t} from "i18next";
 
 import {inject_svg_icons} from "./lib_icons.js";
+import {ensure_drag_canvas_patch} from "./g6_drag_canvas_touch.js";
 
 /***************************************************************
  *  YuiToolbar — G6 Toolbar subclass that adds per-item className
@@ -129,6 +130,7 @@ class YuiToolbar extends Toolbar
     }
 }
 register(ExtensionCategory.PLUGIN, 'yui-toolbar', YuiToolbar);
+ensure_drag_canvas_patch();
 
 /***************************************************************
  *              Constants

--- a/kernel/js/lib-yui/src/c_yui_gobj_tree_js.js
+++ b/kernel/js/lib-yui/src/c_yui_gobj_tree_js.js
@@ -53,6 +53,8 @@ import {
     register,
 } from '@antv/g6';
 
+import { ensure_drag_canvas_patch } from "./g6_drag_canvas_touch.js";
+
 /***************************************************************
  *              Constants
  ***************************************************************/
@@ -88,6 +90,8 @@ let PRIVATE_DATA = {
     $popover_body: null,
     node_by_id: null,       // map of node_id -> node_data (for popover)
     collapse_state: null,   // map of full_name -> "collapsed" | "expanded"
+    resize_observer: null,  // ResizeObserver on the canvas mount element
+    _resize_raf: 0,         // rAF id debouncing resize -> EV_RESIZE
 };
 
 let __gclass__ = null;
@@ -303,6 +307,8 @@ function mt_create(gobj)
 
     build_ui(gobj);
 
+    ensure_drag_canvas_patch();
+
     if(!__layout_registered__) {
         register(ExtensionCategory.LAYOUT, 'gobj-tree-v', GobjTreeVLayout);
         register(ExtensionCategory.LAYOUT, 'gobj-tree-h', GobjTreeHLayout);
@@ -334,6 +340,15 @@ function mt_stop(gobj)
 function mt_destroy(gobj)
 {
     let priv = gobj.priv;
+
+    if(priv.resize_observer) {
+        priv.resize_observer.disconnect();
+        priv.resize_observer = null;
+    }
+    if(priv._resize_raf) {
+        cancelAnimationFrame(priv._resize_raf);
+        priv._resize_raf = 0;
+    }
 
     if(priv.graph) {
         priv.graph.destroy();
@@ -611,7 +626,7 @@ function build_graph(gobj)
     const graph = priv.graph = new Graph({
         container: priv.canvas_id,
         animation: false,
-        autoResize: true,
+        autoResize: false,
         zoomRange: [0.1, 4],
 
         node: {
@@ -648,6 +663,35 @@ function build_graph(gobj)
     graph.on(CanvasEvent.CLICK, (evt) => {
         hide_popover(gobj);
     });
+
+    /*
+     *  Self-contained resize.  G6 v5 autoResize only listens to the
+     *  global window 'resize'; it ignores container-only changes
+     *  (panel/tab/splitter/mobile chrome).  If the configured canvas
+     *  size drifts from its on-screen size, @antv/g getScale() scales
+     *  the pointer delta by bbox.width/offsetWidth and drag-canvas
+     *  panning desyncs (badly on mobile).  Observe the mount box and
+     *  re-sync on every change; rAF-debounced, setSize does not change
+     *  the observed box so there is no feedback loop.
+     */
+    if(typeof ResizeObserver !== "undefined") {
+        let $canvas = document.getElementById(priv.canvas_id);
+        if($canvas) {
+            let ro = new ResizeObserver(() => {
+                if(priv._resize_raf) {
+                    cancelAnimationFrame(priv._resize_raf);
+                }
+                priv._resize_raf = requestAnimationFrame(() => {
+                    priv._resize_raf = 0;
+                    if(priv.graph) {
+                        gobj_send_event(gobj, "EV_RESIZE", {}, gobj);
+                    }
+                });
+            });
+            ro.observe($canvas);
+            priv.resize_observer = ro;
+        }
+    }
 }
 
 /************************************************************
@@ -1907,12 +1951,43 @@ function ac_show(gobj, event, kw, src)
     if(graph) {
         let $canvas = document.getElementById(priv.canvas_id);
         if($canvas) {
-            let rect = $canvas.getBoundingClientRect();
-            if(rect.width > 0 && rect.height > 0) {
-                graph.setSize(rect.width, rect.height);
+            /*
+             *  Content box (clientWidth/Height), not getBoundingClientRect:
+             *  @antv/g lays the canvas into the element's content area and
+             *  getScale() compares bbox.width / offsetWidth.  Sizing to the
+             *  content box keeps that ratio at exactly 1 (no border / sub-px
+             *  drift) so drag-canvas panning stays 1:1.
+             */
+            let cw = $canvas.clientWidth;
+            let ch = $canvas.clientHeight;
+            if(cw > 0 && ch > 0) {
+                graph.setSize(cw, ch);
                 graph.render().then(() => {
                     graph.fitView();
                 });
+            }
+        }
+    }
+
+    return 0;
+}
+
+/************************************************************
+ *  Keep the canvas size in sync with its on-screen box.
+ *  No fitView: preserve the user's current pan/zoom.
+ ************************************************************/
+function ac_resize(gobj, event, kw, src)
+{
+    let priv = gobj.priv;
+    let graph = priv.graph;
+
+    if(graph) {
+        let $canvas = document.getElementById(priv.canvas_id);
+        if($canvas) {
+            let cw = $canvas.clientWidth;
+            let ch = $canvas.clientHeight;
+            if(cw > 0 && ch > 0) {
+                graph.setSize(cw, ch);
             }
         }
     }
@@ -1974,6 +2049,7 @@ function create_gclass(gclass_name)
             ["EV_ZOOM_RESET",           ac_zoom_reset,          null],
             ["EV_CENTER",               ac_center,              null],
             ["EV_NODE_CLICK",           ac_node_click,          null],
+            ["EV_RESIZE",               ac_resize,              null],
             ["EV_SHOW",                 ac_show,                null],
             ["EV_HIDE",                 ac_hide,                null],
         ]]
@@ -1993,6 +2069,7 @@ function create_gclass(gclass_name)
         ["EV_ZOOM_RESET",           0],
         ["EV_CENTER",               0],
         ["EV_NODE_CLICK",           0],
+        ["EV_RESIZE",               0],
         ["EV_SHOW",                 0],
         ["EV_HIDE",                 0],
     ];

--- a/kernel/js/lib-yui/src/c_yui_json_graph.js
+++ b/kernel/js/lib-yui/src/c_yui_json_graph.js
@@ -58,6 +58,8 @@ import {
     register,
 } from '@antv/g6';
 
+import { ensure_drag_canvas_patch } from "./g6_drag_canvas_touch.js";
+
 /***************************************************************
  *              Constants
  ***************************************************************/
@@ -89,6 +91,8 @@ let PRIVATE_DATA = {
     graph: null,
     node_counter: 0,
     theme: null,
+    resize_observer: null,  // ResizeObserver on the canvas mount element
+    _resize_raf: 0,         // rAF id debouncing resize -> EV_RESIZE
 };
 
 let __gclass__ = null;
@@ -149,6 +153,8 @@ function mt_create(gobj)
 
     build_ui(gobj);
 
+    ensure_drag_canvas_patch();
+
     if(!__layout_registered__) {
         register(ExtensionCategory.LAYOUT, 'json-tree-layout', JsonTreeLayout);
         __layout_registered__ = true;
@@ -177,6 +183,15 @@ function mt_stop(gobj)
 function mt_destroy(gobj)
 {
     let priv = gobj.priv;
+
+    if(priv.resize_observer) {
+        priv.resize_observer.disconnect();
+        priv.resize_observer = null;
+    }
+    if(priv._resize_raf) {
+        cancelAnimationFrame(priv._resize_raf);
+        priv._resize_raf = 0;
+    }
 
     if(priv.graph) {
         priv.graph.destroy();
@@ -297,7 +312,7 @@ function build_graph(gobj)
     const graph = priv.graph = new Graph({
         container: priv.canvas_id,
         animation: false,
-        autoResize: true,
+        autoResize: false,
         zoomRange: [0.1, 4],
 
         node: {
@@ -336,6 +351,35 @@ function build_graph(gobj)
     graph.on(CanvasEvent.CLICK, (evt) => {
         // Canvas click
     });
+
+    /*
+     *  Self-contained resize.  G6 v5 autoResize only listens to the
+     *  global window 'resize'; it ignores container-only changes
+     *  (panel/tab/splitter/mobile chrome).  If the configured canvas
+     *  size drifts from its on-screen size, @antv/g getScale() scales
+     *  the pointer delta by bbox.width/offsetWidth and drag-canvas
+     *  panning desyncs (badly on mobile).  Observe the mount box and
+     *  re-sync on every change; rAF-debounced, setSize does not change
+     *  the observed box so there is no feedback loop.
+     */
+    if(typeof ResizeObserver !== "undefined") {
+        let $canvas = document.getElementById(priv.canvas_id);
+        if($canvas) {
+            let ro = new ResizeObserver(() => {
+                if(priv._resize_raf) {
+                    cancelAnimationFrame(priv._resize_raf);
+                }
+                priv._resize_raf = requestAnimationFrame(() => {
+                    priv._resize_raf = 0;
+                    if(priv.graph) {
+                        gobj_send_event(gobj, "EV_RESIZE", {}, gobj);
+                    }
+                });
+            });
+            ro.observe($canvas);
+            priv.resize_observer = ro;
+        }
+    }
 }
 
 /************************************************************
@@ -832,12 +876,43 @@ function ac_show(gobj, event, kw, src)
     if(graph) {
         let $canvas = document.getElementById(priv.canvas_id);
         if($canvas) {
-            let rect = $canvas.getBoundingClientRect();
-            if(rect.width > 0 && rect.height > 0) {
-                graph.setSize(rect.width, rect.height);
+            /*
+             *  Content box (clientWidth/Height), not getBoundingClientRect:
+             *  @antv/g lays the canvas into the element's content area and
+             *  getScale() compares bbox.width / offsetWidth.  Sizing to the
+             *  content box keeps that ratio at exactly 1 (no border / sub-px
+             *  drift) so drag-canvas panning stays 1:1.
+             */
+            let cw = $canvas.clientWidth;
+            let ch = $canvas.clientHeight;
+            if(cw > 0 && ch > 0) {
+                graph.setSize(cw, ch);
                 graph.render().then(() => {
                     graph.fitView();
                 });
+            }
+        }
+    }
+
+    return 0;
+}
+
+/************************************************************
+ *  Keep the canvas size in sync with its on-screen box.
+ *  No fitView: preserve the user's current pan/zoom.
+ ************************************************************/
+function ac_resize(gobj, event, kw, src)
+{
+    let priv = gobj.priv;
+    let graph = priv.graph;
+
+    if(graph) {
+        let $canvas = document.getElementById(priv.canvas_id);
+        if($canvas) {
+            let cw = $canvas.clientWidth;
+            let ch = $canvas.clientHeight;
+            if(cw > 0 && ch > 0) {
+                graph.setSize(cw, ch);
             }
         }
     }
@@ -895,6 +970,7 @@ function create_gclass(gclass_name)
             ["EV_ZOOM_RESET",           ac_zoom_reset,          null],
             ["EV_CENTER",               ac_center,              null],
             ["EV_NODE_CLICK",           ac_node_click,          null],
+            ["EV_RESIZE",               ac_resize,              null],
             ["EV_SHOW",                 ac_show,                null],
             ["EV_HIDE",                 ac_hide,                null],
         ]]
@@ -911,6 +987,7 @@ function create_gclass(gclass_name)
         ["EV_ZOOM_RESET",           0],
         ["EV_CENTER",               0],
         ["EV_NODE_CLICK",           0],
+        ["EV_RESIZE",               0],
         ["EV_SHOW",                 0],
         ["EV_HIDE",                 0],
         ["EV_JSON_ITEM_CLICKED",    event_flag_t.EVF_OUTPUT_EVENT],

--- a/kernel/js/lib-yui/src/g6_drag_canvas_touch.js
+++ b/kernel/js/lib-yui/src/g6_drag_canvas_touch.js
@@ -1,0 +1,141 @@
+/***********************************************************************
+ *          g6_drag_canvas_touch.js
+ *
+ *          Drop-in replacement for G6 v5 built-in 'drag-canvas'.
+ *
+ *          Why this exists
+ *          ----------------
+ *          G6 v5.1.0 drag-canvas computes the pan delta as:
+ *
+ *              const x = event.movement?.x ?? event.dx;
+ *
+ *          but @antv/g always attaches a `movement` Point to every
+ *          federated pointer event (g-lite: `this.movement = new
+ *          Point()`), and fills it from the native
+ *          `PointerEvent.movementX/Y` (g-lite: `event.movement.x =
+ *          nativeEvent.movementX`).  So `event.movement?.x` is never
+ *          nullish and the `?? event.dx` fallback never runs.
+ *
+ *          Native `movementX/Y`:
+ *            - on touch pointers most mobile browsers leave it at 0
+ *              (it is a mouse / pointer-lock feature), so the canvas
+ *              barely pans on mobile;
+ *            - on desktop it is skewed by OS pointer acceleration and
+ *              devicePixelRatio, so the graph lags the cursor.
+ *
+ *          The fix tracks `event.viewport` (the federated pointer
+ *          position already mapped to canvas/viewport space by
+ *          @antv/g, the exact units `translateBy` expects) and pans
+ *          by its frame-to-frame delta.  This is:
+ *            - reliable on mouse AND touch (derived from clientX/Y,
+ *              never from native movementX);
+ *            - correct for ANY canvas scale (it is post-`getScale()`,
+ *              so a configured-vs-displayed size mismatch can no
+ *              longer make panning over- or under-shoot the cursor);
+ *            - the same source G6's own `zoom-canvas` uses for its
+ *              origin (`event.viewport`).
+ *          The subclass reuses all of the built-in clamp/cursor logic
+ *          and only swaps the delta source.
+ *
+ *          Registered globally over the built-in 'drag-canvas' id so
+ *          every graph (tree, json, treedb, editor) is fixed without
+ *          touching each consumer's behaviors list.
+ *
+ *          Copyright (c) 2026, ArtGins.
+ *          All Rights Reserved.
+ ***********************************************************************/
+import {
+    DragCanvas,
+    CommonEvent,
+    ExtensionCategory,
+    register,
+} from '@antv/g6';
+
+/************************************************************
+ *  Custom drag-canvas: same behavior, reliable delta source
+ ************************************************************/
+class DragCanvasTouch extends DragCanvas {
+    constructor(context, options) {
+        super(context, options);
+
+        /*
+         *  Last pointer position in viewport space; null between
+         *  drags so each gesture re-seeds on its first DRAG frame.
+         */
+        this._lastVP = null;
+
+        /*
+         *  The base constructor already bound its own (buggy)
+         *  onDrag.  Replace it with ours; keep base onDragStart /
+         *  onDragEnd (cursor + isDragging) untouched.
+         */
+        this._onDragTouch = (event) => {
+            if(!this.isDragging) {
+                this._lastVP = null;
+                return;
+            }
+            let vp = event.viewport;
+            if(!vp || typeof vp.x !== "number" || typeof vp.y !== "number") {
+                return;
+            }
+            if(this._lastVP === null) {
+                this._lastVP = {x: vp.x, y: vp.y};
+                return;
+            }
+            let x = vp.x - this._lastVP.x;
+            let y = vp.y - this._lastVP.y;
+            this._lastVP.x = vp.x;
+            this._lastVP.y = vp.y;
+            if(x !== 0 || y !== 0) {
+                this.translate([x, y], false);
+            }
+        };
+
+        this._onDragEndReset = () => {
+            this._lastVP = null;
+        };
+
+        let graph = this.context.graph;
+        graph.off(CommonEvent.DRAG, this.onDrag);
+        graph.on(CommonEvent.DRAG, this._onDragTouch);
+        graph.on(CommonEvent.DRAG_END, this._onDragEndReset);
+    }
+
+    update(options) {
+        /*
+         *  super.update() runs unbind+bind, which reinstalls the
+         *  base onDrag.  Swap it back to ours afterwards.
+         */
+        super.update(options);
+
+        let graph = this.context.graph;
+        graph.off(CommonEvent.DRAG, this.onDrag);
+        graph.off(CommonEvent.DRAG, this._onDragTouch);
+        graph.off(CommonEvent.DRAG_END, this._onDragEndReset);
+        graph.on(CommonEvent.DRAG, this._onDragTouch);
+        graph.on(CommonEvent.DRAG_END, this._onDragEndReset);
+    }
+
+    destroy() {
+        let graph = this.context.graph;
+        graph.off(CommonEvent.DRAG, this._onDragTouch);
+        graph.off(CommonEvent.DRAG_END, this._onDragEndReset);
+        super.destroy();
+    }
+}
+
+/************************************************************
+ *  Register once, replacing the built-in 'drag-canvas'
+ ************************************************************/
+let __drag_canvas_patched__ = false;
+
+function ensure_drag_canvas_patch()
+{
+    if(__drag_canvas_patched__) {
+        return;
+    }
+    register(ExtensionCategory.BEHAVIOR, 'drag-canvas', DragCanvasTouch);
+    __drag_canvas_patched__ = true;
+}
+
+export { ensure_drag_canvas_patch };


### PR DESCRIPTION
## Problem

G6 v5 canvas panning was broken: on **mobile/touch** the graph barely moved no matter how far you dragged; on **desktop** the graph lagged behind the cursor.

Root cause is in G6 v5.1.0 `drag-canvas`:

```js
const x = event.movement?.x ?? event.dx;
```

`@antv/g` attaches a `movement` `Point` to **every** federated pointer event and fills it from native `PointerEvent.movementX/Y`, so `event.movement?.x` is never nullish and the `?? event.dx` fallback never runs. Native `movementX/Y`:

- is left at `0` for touch pointers on most mobile browsers (it is a mouse / pointer-lock feature) → canvas barely pans;
- is skewed by OS pointer acceleration / `devicePixelRatio` on desktop → graph lags the cursor.

Reproduces in G6's own online examples (same `drag-canvas`).

## Fix

`src/g6_drag_canvas_touch.js` — a `DragCanvas` subclass that reuses all the built-in clamp/cursor logic but derives the pan delta from `event.viewport`:

- already mapped by `@antv/g` **after** `getScale()`, i.e. the exact units `translateBy` expects;
- reliable on mouse **and** touch (derived from `clientX/Y`, never native `movementX`);
- correct for **any** canvas scale/zoom — a configured-vs-displayed size mismatch can no longer make panning over- or under-shoot the cursor;
- same source G6's own `zoom-canvas` uses for its origin.

Registered once over the built-in `'drag-canvas'` id, so **every** graph (gobj-tree, json-graph, treedb editor) is fixed without touching each consumer's `behaviors` list.

Also stop fighting G6 `autoResize` in `c_yui_gobj_tree_js.js` / `c_yui_json_graph.js` (G6 v5 `autoResize` only listens to window `resize`, not container resizes, while these also called `setSize()` once on show with a stale border-box rect). Switch to `autoResize:false` + a self-contained `ResizeObserver` → `EV_RESIZE` → `ac_resize` sizing the canvas to its content box on every change — the pattern already proven in `c_g6_nodes_tree.js`. Keeps `@antv/g` `getScale()` at 1 so rendering stays crisp.

## Compatibility

Additive and backwards compatible. `EV_RESIZE` is internal to each gclass; consumers (wattyzer, hidraulia, estadodelaire) need no changes. `c_g6_nodes_tree.js` sizing untouched (only the global drag-canvas patch applies).

## Testing

- `npm run build` ✅ · `npm test` ✅ 50/50
- Manually validated on staging (`e.com`): canvas panning now tracks the cursor 1:1 on desktop and mobile.

Note: starting a drag **on a node** in the treedb editor still grabs the node (`drag-element`, edit-mode behavior — out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)