### PR TITLE
security: triage-confirmed candidate hardening fixes

### DIFF
--- a/kernel/c/gobj-c/src/gbuffer.c
+++ b/kernel/c/gobj-c/src/gbuffer.c
@@ -30,6 +30,29 @@ PUBLIC gbuffer_t *gbuffer_create(
     size_t max_memory_size)
 {
     /*---------------------------------*
+     *   Reject a data_size whose +1
+     *   sentinel-byte allocation wraps
+     *   (data_size+1 == 0, i.e. SIZE_MAX).
+     *   Otherwise GBMEM_MALLOC(data_size+1)
+     *   becomes calloc(1,0): a non-NULL
+     *   ~0-byte buffer slips past the
+     *   __max_block__ guard while
+     *   gbuf->data_size stays at SIZE_MAX,
+     *   defeating every later bounds check
+     *   (gbuffer_freebytes / append memmove).
+     *---------------------------------*/
+    if(data_size + 1 == 0) {
+        gobj_log_error(0, LOG_OPT_TRACE_STACK,
+            "function",     "%s", __FUNCTION__,
+            "msgset",       "%s", MSGSET_MEMORY,
+            "msg",          "%s", "data_size overflow (data_size+1 wraps)",
+            "data_size",    "%lu", (unsigned long)data_size,
+            NULL
+        );
+        return NULL;
+    }
+
+    /*---------------------------------*
      *   Alloc memory
      *---------------------------------*/
     gbuffer_t *gbuf = GBMEM_MALLOC(sizeof(*gbuf));

--- a/kernel/c/gobj-c/src/kwid.c
+++ b/kernel/c/gobj-c/src/kwid.c
@@ -2872,7 +2872,8 @@ PRIVATE json_t *collapse(
     json_t *new_kw = json_object();
     const char *key; json_t *jn_value;
     json_object_foreach(kw, key, jn_value) {
-        char *new_path = gbmem_strndup(path, strlen(path)+strlen(key)+2);
+        char *new_path = GBMEM_MALLOC(strlen(path)+strlen(key)+2);
+        strcpy(new_path, path);
         if(strlen(new_path)>0) {
             strcat(new_path, delimiter);
         }
@@ -2915,7 +2916,8 @@ PRIVATE json_t *collapse(
                 json_array_foreach(jn_value, idx, v) {
                     char s_idx[40];
                     snprintf(s_idx, sizeof(s_idx), "%d", idx);
-                    char *new_path2 = gbmem_strndup(new_path, strlen(new_path)+strlen(s_idx)+2);
+                    char *new_path2 = GBMEM_MALLOC(strlen(new_path)+strlen(s_idx)+2);
+                    strcpy(new_path2, new_path);
                     if(strlen(new_path2)>0) {
                         strcat(new_path2, delimiter);
                     }

--- a/kernel/c/libjwt/src/jwt-verify.c
+++ b/kernel/c/libjwt/src/jwt-verify.c
@@ -290,6 +290,22 @@ static int __verify_config_post(jwt_t *jwt, const jwt_config_t *config,
 		// LCOV_EXCL_STOP
 	}
 
+	/* Pin to the exact algorithm, not just the key family. The alg-vs-alg
+	 * checks above never compare the token alg (jwt->alg) on the common
+	 * pinned path where config->alg and config->key->alg are both set and
+	 * equal, and the kty backstop below is only family-granular
+	 * (jwt_alg_required_kty maps every RS / PS alg to JWK_KEY_TYPE_RSA).
+	 * Without this, e.g. an RS512 token verifies against an RS256-pinned
+	 * key. Require exact agreement with whichever alg is pinned. */
+	if (config->alg != JWT_ALG_NONE && jwt->alg != config->alg) {
+		jwt_write_error(jwt, "JWT alg does not match pinned config alg");
+		return JWT_CLAIM_JWT;
+	} else if (config->key->alg != JWT_ALG_NONE &&
+		   jwt->alg != config->key->alg) {
+		jwt_write_error(jwt, "JWT alg does not match pinned key alg");
+		return JWT_CLAIM_JWT;
+	}
+
 	/* Algorithm is now bound from the token (jwt->alg). Defensively confirm
 	 * the JWK's actual key type can carry it. This blocks algorithm
 	 * confusion (GHSA-q843-6q5f-w55g): the alg-vs-alg checks above never

--- a/kernel/c/root-linux/src/c_tcp.c
+++ b/kernel/c/root-linux/src/c_tcp.c
@@ -677,14 +677,24 @@ PRIVATE void set_secure_connected(hgobj gobj)
     gobj_publish_event(gobj, EV_CONNECTED, kw_conn);
 
     int ret = ytls_flush(priv->ytls, priv->sskt);
-    if(ret < -1000) {
+    if(ret == -2222) {
         /*
-         *  A subscriber of EV_RX_DATA (published from flush_clear_data's
-         *  on_clear_data_cb) destroyed this connection re-entrantly: gobj/priv
-         *  are already freed. Mirror the decrypt-path discipline at the
-         *  ytls_decrypt_data callers (ret < -1000) and bail before touching
-         *  gobj/priv. Do NOT call try_to_stop_yevents() here: the gobj is gone.
+         *  Re-entrant free: a subscriber of EV_RX_DATA (published from
+         *  flush_clear_data's on_clear_data_cb) destroyed this connection
+         *  while we were still inside ytls_flush. gobj/priv are already freed.
+         *  Bail before touching them; do NOT call try_to_stop_yevents() — the
+         *  gobj is gone.
          */
+        return;
+    }
+    if(ret < 0) {
+        /*
+         *  TLS error (-1111): the gobj is still alive, so tear it down here,
+         *  matching the decrypt-path discipline at the ytls_decrypt_data
+         *  caller (which calls try_to_stop_yevents() on a TLS error).
+         *  Error already logged in flush_clear_data.
+         */
+        try_to_stop_yevents(gobj);
         return;
     }
 

--- a/kernel/c/root-linux/src/c_tcp.c
+++ b/kernel/c/root-linux/src/c_tcp.c
@@ -676,7 +676,17 @@ PRIVATE void set_secure_connected(hgobj gobj)
 
     gobj_publish_event(gobj, EV_CONNECTED, kw_conn);
 
-    ytls_flush(priv->ytls, priv->sskt);
+    int ret = ytls_flush(priv->ytls, priv->sskt);
+    if(ret < -1000) {
+        /*
+         *  A subscriber of EV_RX_DATA (published from flush_clear_data's
+         *  on_clear_data_cb) destroyed this connection re-entrantly: gobj/priv
+         *  are already freed. Mirror the decrypt-path discipline at the
+         *  ytls_decrypt_data callers (ret < -1000) and bail before touching
+         *  gobj/priv. Do NOT call try_to_stop_yevents() here: the gobj is gone.
+         */
+        return;
+    }
 
     /*
      *  Inactivity model: flush data queued while disconnected and arm the

--- a/kernel/c/root-linux/src/ghttp_parser.c
+++ b/kernel/c/root-linux/src/ghttp_parser.c
@@ -520,9 +520,14 @@ PRIVATE int on_header_value(llhttp_t* llhttp, const char* at, size_t length)
             parser->cur_key
         );
         const char *partial_value = json_string_value(jn_partial_value);
-        pos = strlen(partial_value);
+        // The previous chunk's json_string() store can fail (e.g. invalid
+        // UTF-8), leaving no string under cur_key; then json_object_get returns
+        // NULL and json_string_value(NULL) returns NULL. Guard before strlen()
+        // so a continuation chunk can't deref NULL (attacker-controlled bytes +
+        // TCP segmentation). Restart the accumulator from this chunk instead.
+        pos = partial_value? strlen(partial_value) : 0;
         value = gbmem_malloc(pos + length + 1);
-        if(value) {
+        if(value && pos) {
             memcpy(value, partial_value, pos);
         }
     } else {
@@ -540,7 +545,19 @@ PRIVATE int on_header_value(llhttp_t* llhttp, const char* at, size_t length)
     }
     memcpy(value+pos, at, length);
     value[pos + length] = 0;    // NUL-terminate before json_string() strlen's it (matches on_url/on_header_field)
-    json_object_set_new(parser->jn_headers, parser->cur_key, json_string(value));
+    // json_string() returns NULL on invalid UTF-8; json_object_set_new then
+    // stores nothing. Don't ignore that: log it so the accumulator desync
+    // (next continuation chunk re-reads a missing value) is visible rather
+    // than silently truncating the header.
+    if(json_object_set_new(parser->jn_headers, parser->cur_key, json_string(value)) < 0) {
+        gobj_log_error(gobj, 0,
+            "function",     "%s", __FUNCTION__,
+            "msgset",       "%s", MSGSET_INTERNAL,
+            "msg",          "%s", "cannot store header value (invalid utf-8?)",
+            "key",          "%s", parser->cur_key,
+            NULL
+        );
+    }
     GBMEM_FREE(value);
 
     if(parser->last_key) {

--- a/kernel/c/yev_loop/src/yev_loop.c
+++ b/kernel/c/yev_loop/src/yev_loop.c
@@ -513,6 +513,13 @@ PRIVATE int callback_cqe(yev_loop_t *yev_loop, struct io_uring_cqe *cqe)
     /*-------------------------------*
      *      cqe ready
      *-------------------------------*/
+    /*
+     *  Mark the event "in dispatch" so a callback that calls yev_destroy_event()
+     *  on its own event defers the free (sets destroy_requested) instead of
+     *  freeing synchronously. Otherwise the post-callback re-arm below would
+     *  dereference freed memory (use-after-free) when this was the last in-flight CQE.
+     */
+    yev_event->in_dispatch = TRUE;
     int ret = 0;
     switch((yev_type_t)yev_event->type) {
         case YEV_CONNECT_TYPE: // cqe ready
@@ -572,7 +579,7 @@ PRIVATE int callback_cqe(yev_loop_t *yev_loop, struct io_uring_cqe *cqe)
                         yev_event
                     );
                 }
-                if(ret == 0 && yev_loop->running &&
+                if(ret == 0 && !yev_event->destroy_requested && yev_loop->running &&
                         yev_event->state == YEV_ST_IDLE &&
                         !(yev_event->flag & YEV_FLAG_ACCEPT_DUP2)) {
                     if(!gobj || (gobj && gobj_is_running(gobj))) {
@@ -679,7 +686,8 @@ PRIVATE int callback_cqe(yev_loop_t *yev_loop, struct io_uring_cqe *cqe)
                     );
                 }
 
-                if(ret == 0 && yev_loop->running && yev_event->state == YEV_ST_IDLE &&
+                if(ret == 0 && !yev_event->destroy_requested && yev_loop->running &&
+                        yev_event->state == YEV_ST_IDLE &&
                         (yev_event->flag & YEV_FLAG_TIMER_PERIODIC)) {
                     if(!gobj || (gobj && gobj_is_running(gobj))) {
                         /*
@@ -718,6 +726,19 @@ PRIVATE int callback_cqe(yev_loop_t *yev_loop, struct io_uring_cqe *cqe)
                 }
             }
             break;
+    }
+
+    /*
+     *  Dispatch (callback + re-arm) finished: it is now safe to touch / free
+     *  the event. If the callback requested destruction while in dispatch,
+     *  yev_destroy_event deferred the free to here. If no op was re-armed
+     *  (in_flight drained to 0) free now; otherwise the deferred free happens
+     *  when the last outstanding CQE drains (see top of callback_cqe).
+     */
+    yev_event->in_dispatch = FALSE;
+    if(yev_event->destroy_requested && yev_event->in_flight <= 0) {
+        really_free_yev_event(yev_event);
+        return ret;
     }
 
     return ret;
@@ -2031,6 +2052,18 @@ PUBLIC void yev_destroy_event(yev_event_h yev_event_)
      *  UAF — and deferring then would leak the event (nothing left to drain
      *  it). Free synchronously in that case.
      *-----------------------------------------------------------------*/
+    /*
+     *  If we are inside callback_cqe's dispatch of this very event (a callback
+     *  destroying its own event), never free synchronously: the caller is
+     *  callback_cqe and it will still dereference the event in the re-arm block
+     *  and the dispatch tail. Defer; callback_cqe frees it once dispatch ends
+     *  and any re-armed op has drained.
+     */
+    if(yev_event->in_dispatch) {
+        yev_event->destroy_requested = TRUE;
+        return;
+    }
+
     if(yev_event->in_flight > 0 && yev_loop->running) {
         yev_event->destroy_requested = TRUE;
         return;

--- a/kernel/c/yev_loop/src/yev_loop.h
+++ b/kernel/c/yev_loop/src/yev_loop.h
@@ -144,6 +144,7 @@ struct yev_event_s {
 
     int in_flight;             // # of submitted SQEs whose CQE has not been reaped yet
     uint8_t destroy_requested; // set when destroyed while in-flight; free is deferred to callback_cqe
+    uint8_t in_dispatch;       // set while callback_cqe is dispatching this event's callback / re-arm
 };
 
 typedef int (*yev_protocol_fill_hints_fn_t)( // fill hints according the schema

--- a/kernel/c/ytls/src/tls/openssl.c
+++ b/kernel/c/ytls/src/tls/openssl.c
@@ -1492,7 +1492,11 @@ PRIVATE const char *last_error(hsskt sskt_)
 PRIVATE int flush(hsskt sskt)
 {
     flush_encrypted_data(sskt);
-    flush_clear_data(sskt);
+    int ret = flush_clear_data(sskt);
+    if(ret < 0) {
+        // Error already logged in flush_clear_data (incl. -2222 re-entrant-free sentinel)
+        return ret;
+    }
     return 0;
 }
 

--- a/tests/c/gbuffer/test_gbuffer_guards.c
+++ b/tests/c/gbuffer/test_gbuffer_guards.c
@@ -50,6 +50,20 @@ PRIVATE void test_sink_graceful(void)
 }
 
 /***************************************************************************
+ *  Wrap guard: a data_size whose +1 sentinel allocation overflows
+ *  (SIZE_MAX) must be rejected at creation, not turned into a
+ *  non-NULL ~0-byte buffer with data_size==SIZE_MAX. This is the
+ *  integer-overflow boundary the __max_block__ guard alone misses
+ *  (it catches every merely-large value but not the exact wrap).
+ ***************************************************************************/
+PRIVATE void test_wrap_guard(void)
+{
+    gbuffer_t *gbuf = gbuffer_create((size_t)-1, (size_t)-1);
+    ok_or_fail(gbuf == NULL, "gbuffer_create(SIZE_MAX,...) == NULL");
+    GBUFFER_DECREF(gbuf);
+}
+
+/***************************************************************************
  *  Valid gbuffer: accessors still return real, usable data.
  ***************************************************************************/
 PRIVATE void test_valid_path(void)
@@ -111,6 +125,7 @@ int main(int argc, char *argv[])
      *----------------------------------*/
     test_null_guards();
     test_sink_graceful();
+    test_wrap_guard();
     test_valid_path();
 
     gobj_end();

--- a/yunos/c/emailsender/src/c_emailsender.c
+++ b/yunos/c/emailsender/src/c_emailsender.c
@@ -973,14 +973,31 @@ PRIVATE int tira_dela_cola(hgobj gobj)
     const char *reply_to = kw_get_str(gobj, msg, "reply_to", "", 0);
     const char *subject = kw_get_str(gobj, msg, "subject", "", 0);
 
+    const char *attachment = kw_get_str(gobj, msg, "attachment", "", 0);
+    if(empty_string(attachment)) {
+        /* Legacy alias from c_curl era. */
+        attachment = kw_get_str(gobj, msg, "attachments", "", 0);
+    }
+    const char *inline_file_id = kw_get_str(gobj, msg, "inline_file_id", 0, 0);
+
     /*
      *  Reject CR/LF/control chars in any single-line header / envelope field
      *  before they reach an SMTP command line (MAIL FROM/RCPT TO) or a MIME
      *  header. Without this a newline injects extra SMTP commands (RCPT, DATA
      *  smuggling) or extra MIME headers/body — SMTP command / email header
      *  injection. Treated as a permanent send failure.
+     *
+     *  attachment (its basename feeds Content-Type name="%s" /
+     *  Content-Disposition filename="%s") and inline_file_id (feeds
+     *  Content-ID: <%s>) are interpolated raw into MIME headers by
+     *  append_attachment_part() in mime_encoder.c, so they must be checked
+     *  here too — they are not display fields but reach the same header
+     *  stream. EV_SEND_EMAIL is a public event, so these are attacker-reachable.
      */
-    const char *single_line_fields[] = {from, from_beautiful, to, cc, bcc, reply_to, subject};
+    const char *single_line_fields[] = {
+        from, from_beautiful, to, cc, bcc, reply_to, subject,
+        attachment, inline_file_id
+    };
     for(unsigned f = 0; f < sizeof(single_line_fields)/sizeof(single_line_fields[0]); f++) {
         if(email_field_has_ctrl(single_line_fields[f])) {
             gobj_log_error(gobj, 0,
@@ -996,12 +1013,6 @@ PRIVATE int tira_dela_cola(hgobj gobj)
         }
     }
 
-    const char *attachment = kw_get_str(gobj, msg, "attachment", "", 0);
-    if(empty_string(attachment)) {
-        /* Legacy alias from c_curl era. */
-        attachment = kw_get_str(gobj, msg, "attachments", "", 0);
-    }
-    const char *inline_file_id = kw_get_str(gobj, msg, "inline_file_id", 0, 0);
     BOOL is_html = kw_get_bool(gobj, msg, "is_html", 0, 0);
 
     /*--------------------------------*


### PR DESCRIPTION
## Summary

Eight attacker-reachable hardening fixes across the C kernel and the emailsender yuno, triaged and confirmed. Each closes a concrete memory-safety or injection gap; none changes behaviour for legitimate inputs.

| # | File | Issue closed |
|---|------|--------------|
| 1 | `gbuffer.c` | Integer overflow: `data_size == SIZE_MAX` made `GBMEM_MALLOC(data_size+1)` a `malloc(0)` — a non-NULL tiny buffer that passed the `__max_block__` guard while `data_size` stayed `SIZE_MAX`, defeating every later bounds check. Now rejected at creation. |
| 2 | `kwid.c` | OOB heap **over-read**: in-tree `gbmem_strndup` is a raw `memmove(size)` (not a real `strndup`), so `collapse()` read past `path` by `strlen(key)+1` bytes and left the buffer unterminated. Replaced with `GBMEM_MALLOC`+`strcpy` (exact sizing). |
| 3 | `jwt-verify.c` | Algorithm downgrade within a key family: the alg-vs-alg chain never compared the token alg on the common pinned path, and the `kty` backstop is family-granular — an RS512 token verified against an RS256-pinned key. Added exact-alg pinning (purely additive; no false rejects). |
| 4 | `yev_loop.c` / `.h` | Use-after-free: a callback destroying its own event freed synchronously, then `callback_cqe`'s re-arm/tail dereferenced freed memory. New `in_dispatch` flag defers the free to the dispatch tail. |
| 5 | `ghttp_parser.c` | NULL deref: a prior chunk's `json_string()` failing on invalid UTF-8 left no value, so the next continuation chunk hit `strlen(NULL)` (attacker bytes + TCP segmentation). Guarded + logged. |
| 6 | `c_tcp.c` | (a) Re-entrant-free UAF on the post-handshake `ytls_flush`; (b) split the `-2222` (freed → bail) and `-1111` (TLS error, gobj alive → tear down) sentinels so a real TLS error no longer leaves a half-open connection. |
| 7 | `openssl.c` | `flush()` now propagates `flush_clear_data`'s negative return (incl. the `-2222` re-entrant-free sentinel) instead of swallowing it. |
| 8 | `c_emailsender.c` | SMTP/MIME header injection: `attachment` (basename → `Content-Type`/`Content-Disposition`) and `inline_file_id` (→ `Content-ID`) reach the header stream raw via `EV_SEND_EMAIL` (public) but weren't CRLF-checked. Added to the control-char rejection set. |

Plus `test_gbuffer_guards.c`: a wrap-boundary regression test for #1.

## Validation

- `yunetas clean && yunetas build` — exit 0, **0 errors** (kernel libs + yunos + tests relinked).
- `ctest` full suite — **110/110 passed** (~494s), including `perf_c_tcps` (TLS/c_tcp), `perf_auth_bff` (jwt), `test_c_llhttp_parser` (ghttp_parser), `test_tcp_reconnect` (yev_loop), `test_gbuffer_guards`, `test_jwt_alg_confusion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)